### PR TITLE
Introducing transform nodes, drawables and items and refined the architecture of scene

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,6 +4,7 @@
 #---------------------------------------------
 
 file(GLOB CORE_HEADERS
+    "stl/*.h"
     "math/*.h"
     "json/*.h"
     "*.h"
@@ -11,6 +12,7 @@ file(GLOB CORE_HEADERS
 
 file(GLOB CORE_SOURCES
     "*.cpp"
+    "stl/*.cpp"
     "json/*.cpp"
 )
 
@@ -28,6 +30,7 @@ target_include_directories(core PUBLIC ".." PRIVATE "." )
 
 target_compile_features(core PRIVATE cxx_std_17)
 
+source_group(core\\stl REGULAR_EXPRESSION stl/*)
 source_group(core\\math REGULAR_EXPRESSION math/*)
 source_group(core\\json REGULAR_EXPRESSION json/*)
 source_group(core REGULAR_EXPRESSION ./*)

--- a/src/core/math/LinearAlgebra.h
+++ b/src/core/math/LinearAlgebra.h
@@ -233,7 +233,7 @@ namespace core
                      yuv.x + 2.032f * yuv.y);
     }
 
-    // Matrix: 3 raws . 4 columns
+    // Matrix: 4 columns 3 rows 
     struct mat4x3 {
         vec3 _columns[4]{ {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 0.0f} };
         float* data() { return _columns[0].data(); }
@@ -246,7 +246,47 @@ namespace core
             _columns[2] = (c2);
             _columns[3] = (c3);
         }
+
+        vec4 row_0() const { return { _columns[0].x, _columns[1].x, _columns[2].x, _columns[3].x }; }
+        vec4 row_1() const { return { _columns[0].y, _columns[1].y, _columns[2].y, _columns[3].y }; }
+        vec4 row_2() const { return { _columns[0].z, _columns[1].z, _columns[2].z, _columns[3].z }; }
+
+        const vec3& x() const { return _columns[0]; }
+        const vec3& y() const { return _columns[1]; }
+        const vec3& z() const { return _columns[2]; }
+
+        vec3 row_x() const { return { _columns[0].x, _columns[1].x, _columns[2].x}; }
+        vec3 row_y() const { return { _columns[0].y, _columns[1].y, _columns[2].y }; }
+        vec3 row_z() const { return { _columns[0].z, _columns[1].z, _columns[2].z }; }
+
+        const vec3& o() const { return _columns[3]; }
+
+
+        static mat4x3 translation(const vec3& t) {
+            mat4x3 mt;
+            mt._columns[3] = t;
+            return mt;
+        }
     };
+
+    inline mat4x3 mul(const mat4x3& a, const mat4x3& b) {
+        auto a_row_0 = a.row_x();
+        auto a_row_1 = a.row_y();
+        auto a_row_2 = a.row_z();
+
+        return {{ dot(a_row_0, b.x()),
+                  dot(a_row_1, b.x()),
+                  dot(a_row_2, b.x()) },
+                        { dot(a_row_0, b.y()),
+                          dot(a_row_1, b.y()),
+                          dot(a_row_2, b.y()) },
+                                { dot(a_row_0, b.z()),
+                                  dot(a_row_1, b.z()),
+                                  dot(a_row_2, b.z()) },
+                                        { dot(a_row_0, b.o()) + a.o().x,
+                                          dot(a_row_1, b.o()) + a.o().y,
+                                          dot(a_row_2, b.o()) + a.o().z }};
+    }
 
     // Matrix: 3 raws . 4 columns
     struct mat4 {

--- a/src/core/math/LinearAlgebra.h
+++ b/src/core/math/LinearAlgebra.h
@@ -309,6 +309,21 @@ namespace core
     };
 
 
+    struct aabox3 {
+        vec3 center{ 0.0f };
+        vec3 half_size{ 1.0f };
+
+        aabox3() {};
+        aabox3(const vec3& center) : center(center) {};
+        aabox3(const vec3& center, const vec3& half_size) : center(center), half_size(half_size) {};
+
+        vec4 toSphere() const { return vec4(center, length(half_size)); }
+
+        static aabox3 fromMinMax(const vec3& minPos, const vec3& maxPos) {
+             return aabox3((minPos + maxPos) *  0.5, (maxPos - minPos) * 0.5);
+        }
+    };
+
     struct Bounds {
         vec3 _minPos{ 0.0f };
         vec3 _maxPos{ 0.0f };
@@ -322,6 +337,10 @@ namespace core
             vec3 center = (_maxPos + _minPos) * 0.5;
             float radius = 0.5f * length(_maxPos - _minPos);
             return vec4(center, radius);
+        }
+
+        aabox3 toBox() {
+            return aabox3::fromMinMax(_minPos, _maxPos);
         }
     };
 

--- a/src/core/stl/IndexTable.cpp
+++ b/src/core/stl/IndexTable.cpp
@@ -1,0 +1,28 @@
+// IndexTable.cpp
+//
+// Sam Gateau - October 2020
+// 
+// MIT License
+//
+// Copyright (c) 2020 Sam Gateau
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#include "IndexTable.h"
+

--- a/src/core/stl/IndexTable.h
+++ b/src/core/stl/IndexTable.h
@@ -1,0 +1,95 @@
+// IndexTable.h 
+//
+// Sam Gateau - October 2020
+// 
+// MIT License
+//
+// Copyright (c) 2020 Sam Gateau
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#pragma once
+#include <stdint.h>
+#include <vector>
+#include <atomic>
+#include <mutex>
+
+//#include "dllmain.h"
+
+namespace core {
+
+    class IndexTable {
+    public:
+        using Index = uint32_t;
+        using Indices = std::vector<Index>;
+        static const Index INVALID_INDEX{ (Index) -1 };
+
+        IndexTable() {}
+        ~IndexTable() {}
+
+        Index getNumElements() const { return _num_allocated_elements - (Index) _invalid_elements.size(); }
+        Index getNumAllocatedElements() const { return _num_allocated_elements; }
+
+        bool isValid(Index index) const {
+            if (index < 0 || index >= _num_allocated_elements) {
+                return false;
+            }
+            for (const auto& invalid : _invalid_elements) {
+                if (index == invalid) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        Index allocate() {
+            Index new_index;
+            if (_invalid_elements.size()) {
+                new_index = _invalid_elements.back();
+                _invalid_elements.pop_back();
+            } else {
+                new_index = _num_allocated_elements;
+                _num_allocated_elements++;
+            }
+            return new_index;
+        }
+
+        Indices allocate(Index num_elements) {
+            Indices allocated(num_elements, INVALID_INDEX);
+            for (auto& index : allocated) {
+                index = allocate();
+            }
+            return std::move(allocated);
+        }
+
+        void free(Index index) {
+            _invalid_elements.push_back(index);
+        }
+
+        void free(const Indices& indices) {
+            _invalid_elements.insert(_invalid_elements.end(), indices.begin(), indices.end());
+        }
+
+    private:
+        Index _num_allocated_elements{ (Index) 0 };
+        std::vector<Index> _invalid_elements;
+
+    };
+
+}

--- a/src/graphics/drawables/GizmoDrawable.cpp
+++ b/src/graphics/drawables/GizmoDrawable.cpp
@@ -1,0 +1,172 @@
+// GizmoDrawable.cpp
+//
+// Sam Gateau - June 2020
+// 
+// MIT License
+//
+// Copyright (c) 2020 Sam Gateau
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#include "GizmoDrawable.h"
+
+#include "gpu/Device.h"
+#include "gpu/Batch.h"
+#include "gpu/Shader.h"
+#include "gpu/Resource.h"
+#include "gpu/Pipeline.h"
+#include "gpu/Descriptor.h"
+#include "gpu/Swapchain.h"
+
+#include "render/Renderer.h"
+#include "render/Camera.h"
+#include "render/Scene.h"
+#include "render/Drawable.h"
+#include "render/Viewport.h"
+#include "render/Mesh.h"
+
+#include "Gizmo_vert.h"
+#include "Gizmo_frag.h"
+
+//using namespace view3d;
+namespace graphics
+{
+
+    GizmoDrawableFactory::GizmoDrawableFactory() :
+        _sharedUniforms(std::make_shared<GizmoDrawableUniforms>()) {
+
+    }
+    GizmoDrawableFactory::~GizmoDrawableFactory() {
+
+    }
+
+    // Custom data uniforms
+    struct GizmoObjectData {
+        core::mat4x3 transform;
+        uint32_t numVertices{ 0 };
+        uint32_t numIndices{ 0 };
+        uint32_t stride{ 0 };
+        float triangleScale { 0.1f };
+    };
+
+    void GizmoDrawableFactory::allocateGPUShared(const graphics::DevicePointer& device) {
+
+        // Let's describe the pipeline Descriptors layout
+        graphics::DescriptorLayouts descriptorLayouts{
+            { graphics::DescriptorType::UNIFORM_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
+            { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(GizmoObjectData) >> 2},
+        };
+
+        graphics::DescriptorSetLayoutInit descriptorSetLayoutInit{ descriptorLayouts };
+        auto descriptorSetLayout = device->createDescriptorSetLayout(descriptorSetLayoutInit);
+
+        // And a Pipeline
+
+        // Load shaders (as stored in the resources)
+        auto shader_vertex_src = Gizmo_vert::getSource();
+        auto shader_pixel_src = Gizmo_frag::getSource();
+
+        // test: create shader
+        graphics::ShaderInit vertexShaderInit{ graphics::ShaderType::VERTEX, "main", "", shader_vertex_src, Gizmo_vert::getSourceFilename() };
+        graphics::ShaderPointer vertexShader = device->createShader(vertexShaderInit);
+
+        graphics::ShaderInit pixelShaderInit{ graphics::ShaderType::PIXEL, "main", "", shader_pixel_src, Gizmo_frag::getSourceFilename() };
+        graphics::ShaderPointer pixelShader = device->createShader(pixelShaderInit);
+
+        graphics::ProgramInit programInit{ vertexShader, pixelShader };
+        graphics::ShaderPointer programShader = device->createProgram(programInit);
+
+        graphics::PipelineStateInit pipelineInit{
+                    programShader,
+                    StreamLayout(),
+                    graphics::PrimitiveTopology::LINE,
+                    descriptorSetLayout,
+                    RasterizerState(),
+                    true, // enable depth
+                    BlendState()
+        };
+        _pipeline = device->createPipelineState(pipelineInit);
+    }
+
+    graphics::GizmoDrawable* GizmoDrawableFactory::createGizmoDrawable(const graphics::DevicePointer& device) {
+
+        auto gizmoDrawable = new GizmoDrawable();
+        gizmoDrawable->_bounds._maxPos = core::vec3(1.0f);
+        gizmoDrawable->_bounds._minPos = core::vec3(-1.0f);
+
+        // Create the triangle soup drawable using the shared uniforms of the factory
+        gizmoDrawable->_uniforms = _sharedUniforms;
+
+        return gizmoDrawable;
+    }
+
+    graphics::DrawcallObjectPointer GizmoDrawableFactory::allocateDrawcallObject(const graphics::DevicePointer& device,
+        const graphics::CameraPointer& camera, const graphics::GizmoDrawablePointer& gizmo)
+    {
+        // It s time to create a descriptorSet that matches the expected pipeline descriptor set
+        // then we will assign a uniform buffer in it
+        graphics::DescriptorSetInit descriptorSetInit{
+            _pipeline->getDescriptorSetLayout()
+        };
+        auto descriptorSet = device->createDescriptorSet(descriptorSetInit);
+
+        // Assign the Camera UBO just created as the resource of the descriptorSet
+        // auto descriptorObjects = descriptorSet->buildDescriptorObjects();
+        graphics::DescriptorObject uboDescriptorObject;
+        uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
+        graphics::DescriptorObjects descriptorObjects = {
+            uboDescriptorObject
+        };
+        device->updateDescriptorSet(descriptorSet, descriptorObjects);
+
+        // And now a render callback where we describe the rendering sequence
+        graphics::DrawObjectCallback drawCallback = [gizmo, descriptorSet, this](const core::mat4x3& transform, const graphics::CameraPointer& camera, const graphics::SwapchainPointer& swapchain, const graphics::DevicePointer& device, const graphics::BatchPointer& batch) {
+            batch->setPipeline(this->_pipeline);
+            batch->setViewport(camera->getViewportRect());
+            batch->setScissor(camera->getViewportRect());
+
+            batch->bindDescriptorSet(descriptorSet);
+
+            auto uniforms = gizmo->getUniforms();
+            GizmoObjectData odata{ transform, 0, 0, 0, uniforms->triangleScale };
+            batch->bindPushUniform(1, sizeof(GizmoObjectData), (const uint8_t*)&odata);
+
+            batch->draw(6, 0);
+        };
+        auto drawcall = new graphics::DrawcallObject(drawCallback);
+        drawcall->_bounds = gizmo->_bounds;
+        drawcall->_transform = gizmo->_transform;
+        gizmo->_drawcall = graphics::DrawcallObjectPointer(drawcall);
+
+        return gizmo->_drawcall;
+    }
+
+
+    GizmoDrawable::GizmoDrawable() {
+
+    }
+    GizmoDrawable::~GizmoDrawable() {
+
+    }
+       
+    graphics::DrawcallObjectPointer GizmoDrawable::getDrawable() const {
+        return _drawcall;
+    }
+
+} // !namespace graphics

--- a/src/graphics/drawables/GizmoDrawable.cpp
+++ b/src/graphics/drawables/GizmoDrawable.cpp
@@ -41,7 +41,8 @@
 #include "render/Viewport.h"
 #include "render/Mesh.h"
 
-#include "Gizmo_vert.h"
+#include "GizmoNode_vert.h"
+#include "GizmoItem_vert.h"
 #include "Gizmo_frag.h"
 
 //using namespace view3d;
@@ -68,47 +69,70 @@ namespace graphics
     void GizmoDrawableFactory::allocateGPUShared(const graphics::DevicePointer& device) {
 
         // Let's describe the pipeline Descriptors layout
-        graphics::DescriptorLayouts descriptorLayouts{
+        graphics::DescriptorLayouts descriptorLayouts_node{
+            { graphics::DescriptorType::UNIFORM_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
+            { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(GizmoObjectData) >> 2},
+            { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
+        };
+        graphics::DescriptorLayouts descriptorLayouts_item{
             { graphics::DescriptorType::UNIFORM_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
             { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(GizmoObjectData) >> 2},
             { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
             { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 1, 1},
+            { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 2, 1},
         };
 
-        graphics::DescriptorSetLayoutInit descriptorSetLayoutInit{ descriptorLayouts };
-        auto descriptorSetLayout = device->createDescriptorSetLayout(descriptorSetLayoutInit);
+        graphics::DescriptorSetLayoutInit descriptorSetLayoutInit_node{ descriptorLayouts_node };
+        auto descriptorSetLayout_node = device->createDescriptorSetLayout(descriptorSetLayoutInit_node);
+        graphics::DescriptorSetLayoutInit descriptorSetLayoutInit_item{ descriptorLayouts_item };
+        auto descriptorSetLayout_item = device->createDescriptorSetLayout(descriptorSetLayoutInit_item);
 
         // And a Pipeline
 
-        // Load shaders (as stored in the resources)
-        auto shader_vertex_src = Gizmo_vert::getSource();
         auto shader_pixel_src = Gizmo_frag::getSource();
 
         // test: create shader
-        graphics::ShaderInit vertexShaderInit{ graphics::ShaderType::VERTEX, "main", "", shader_vertex_src, Gizmo_vert::getSourceFilename() };
-        graphics::ShaderPointer vertexShader = device->createShader(vertexShaderInit);
+        graphics::ShaderInit vertexShaderInit_node{ graphics::ShaderType::VERTEX, "main", "", GizmoNode_vert::getSource(), GizmoNode_vert::getSourceFilename() };
+        graphics::ShaderPointer vertexShader_node = device->createShader(vertexShaderInit_node);
+
+        graphics::ShaderInit vertexShaderInit_item{ graphics::ShaderType::VERTEX, "main", "", GizmoItem_vert::getSource(), GizmoItem_vert::getSourceFilename() };
+        graphics::ShaderPointer vertexShader_item = device->createShader(vertexShaderInit_item);
 
         graphics::ShaderInit pixelShaderInit{ graphics::ShaderType::PIXEL, "main", "", shader_pixel_src, Gizmo_frag::getSourceFilename() };
         graphics::ShaderPointer pixelShader = device->createShader(pixelShaderInit);
 
-        graphics::ProgramInit programInit{ vertexShader, pixelShader };
-        graphics::ShaderPointer programShader = device->createProgram(programInit);
+        graphics::ProgramInit programInit_node{ vertexShader_node, pixelShader };
+        graphics::ShaderPointer programShader_node = device->createProgram(programInit_node);
 
-        graphics::PipelineStateInit pipelineInit{
-                    programShader,
+        graphics::ProgramInit programInit_item{ vertexShader_item, pixelShader };
+        graphics::ShaderPointer programShader_item = device->createProgram(programInit_item);
+
+        graphics::PipelineStateInit pipelineInit_node{
+                    programShader_node,
                     StreamLayout(),
                     graphics::PrimitiveTopology::LINE,
-                    descriptorSetLayout,
+                    descriptorSetLayout_node,
                     RasterizerState(),
                     true, // enable depth
                     BlendState()
         };
-        _pipeline = device->createPipelineState(pipelineInit);
+        _nodePipeline = device->createPipelineState(pipelineInit_node);
+
+        graphics::PipelineStateInit pipelineInit_item{
+                    programShader_item,
+                    StreamLayout(),
+                    graphics::PrimitiveTopology::LINE,
+                    descriptorSetLayout_item,
+                    RasterizerState(),
+                    true, // enable depth
+                    BlendState()
+        };
+        _itemPipeline = device->createPipelineState(pipelineInit_item);
     }
 
-    graphics::GizmoDrawable* GizmoDrawableFactory::createGizmoDrawable(const graphics::DevicePointer& device) {
+    graphics::NodeGizmo* GizmoDrawableFactory::createNodeGizmo(const graphics::DevicePointer& device) {
 
-        auto gizmoDrawable = new GizmoDrawable();
+        auto gizmoDrawable = new NodeGizmo();
 
         // Create the triangle soup drawable using the shared uniforms of the factory
         gizmoDrawable->_uniforms = _sharedUniforms;
@@ -116,15 +140,26 @@ namespace graphics
         return gizmoDrawable;
     }
 
-    graphics::DrawcallObjectPointer GizmoDrawableFactory::allocateDrawcallObject(const graphics::DevicePointer& device,
-        const graphics::TransformTreeGPUPointer& transform,
+    graphics::ItemGizmo* GizmoDrawableFactory::createItemGizmo(const graphics::DevicePointer& device) {
+
+        auto gizmoDrawable = new ItemGizmo();
+
+        // Create the triangle soup drawable using the shared uniforms of the factory
+        gizmoDrawable->_uniforms = _sharedUniforms;
+
+        return gizmoDrawable;
+    }
+
+   void GizmoDrawableFactory::allocateDrawcallObject(
+        const graphics::DevicePointer& device,
+        const graphics::ScenePointer& scene,
         const graphics::CameraPointer& camera,
-        const graphics::GizmoDrawablePointer& gizmo)
+        graphics::NodeGizmo& gizmo)
     {
         // It s time to create a descriptorSet that matches the expected pipeline descriptor set
         // then we will assign a uniform buffer in it
         graphics::DescriptorSetInit descriptorSetInit{
-            _pipeline->getDescriptorSetLayout()
+            _nodePipeline->getDescriptorSetLayout()
         };
         auto descriptorSet = device->createDescriptorSet(descriptorSetInit);
 
@@ -133,48 +168,82 @@ namespace graphics
         graphics::DescriptorObject camera_uboDescriptorObject;
         camera_uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
         graphics::DescriptorObject transform_rboDescriptorObject;
-        transform_rboDescriptorObject._buffers.push_back(transform->_transforms_buffer);
-        graphics::DescriptorObject bound_rboDescriptorObject;
-        bound_rboDescriptorObject._buffers.push_back(transform->_bounds_buffer);
+        transform_rboDescriptorObject._buffers.push_back(scene->_nodes._transforms_buffer);
         graphics::DescriptorObjects descriptorObjects = {
             camera_uboDescriptorObject,
-            transform_rboDescriptorObject,
-            bound_rboDescriptorObject
+            transform_rboDescriptorObject
         };
         device->updateDescriptorSet(descriptorSet, descriptorObjects);
 
+        auto pgizmo = &gizmo;
+        auto pipeline = this->_nodePipeline;
+
         // And now a render callback where we describe the rendering sequence
-        graphics::DrawObjectCallback drawCallback = [gizmo, descriptorSet, this](const NodeID node, const graphics::CameraPointer& camera, const graphics::SwapchainPointer& swapchain, const graphics::DevicePointer& device, const graphics::BatchPointer& batch) {
-            batch->setPipeline(this->_pipeline);
+        graphics::DrawObjectCallback drawCallback = [pgizmo, descriptorSet, pipeline](const NodeID node, const graphics::CameraPointer& camera, const graphics::SwapchainPointer& swapchain, const graphics::DevicePointer& device, const graphics::BatchPointer& batch) {
+            batch->setPipeline(pipeline);
             batch->setViewport(camera->getViewportRect());
             batch->setScissor(camera->getViewportRect());
 
             batch->bindDescriptorSet(descriptorSet);
 
-            auto uniforms = gizmo->getUniforms();
-            GizmoObjectData odata{ node, 0, 0, 0, uniforms->triangleScale };
+            GizmoObjectData odata{ node, 0, 0, 0, pgizmo->getUniforms()->triangleScale };
             batch->bindPushUniform(1, sizeof(GizmoObjectData), (const uint8_t*)&odata);
 
-            batch->draw(gizmo->nodes.size() * 2 * (3 + 1 + 12), 0);
+            batch->draw(pgizmo->nodes.size() * 2 * (3 + 1), 0);
         };
-        auto drawcall = new graphics::DrawcallObject(drawCallback);
-        gizmo->_drawcall = graphics::DrawcallObjectPointer(drawcall);
-
-        return gizmo->_drawcall;
+        gizmo._drawcall = drawCallback;
     }
 
 
-    GizmoDrawable::GizmoDrawable() {
+   void GizmoDrawableFactory::allocateDrawcallObject(
+        const graphics::DevicePointer& device,
+        const graphics::ScenePointer& scene,
+        const graphics::CameraPointer& camera,
+        graphics::ItemGizmo& gizmo)
+   {
+       // It s time to create a descriptorSet that matches the expected pipeline descriptor set
+       // then we will assign a uniform buffer in it
+       graphics::DescriptorSetInit descriptorSetInit{
+           _itemPipeline->getDescriptorSetLayout()
+       };
+       auto descriptorSet = device->createDescriptorSet(descriptorSetInit);
 
-    }
-    GizmoDrawable::~GizmoDrawable() {
+       // Assign the Camera UBO just created as the resource of the descriptorSet
+       // auto descriptorObjects = descriptorSet->buildDescriptorObjects();
+       graphics::DescriptorObject camera_uboDescriptorObject;
+       camera_uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
+       graphics::DescriptorObject items_rboDescriptorObject;
+       items_rboDescriptorObject._buffers.push_back(scene->_items._items_buffer);
+       graphics::DescriptorObject transform_rboDescriptorObject;
+       transform_rboDescriptorObject._buffers.push_back(scene->_nodes._transforms_buffer);
+       graphics::DescriptorObject drawables_rboDescriptorObject;
+       drawables_rboDescriptorObject._buffers.push_back(scene->_drawables._drawables_buffer);
 
-    }
-    void GizmoDrawable::setNode(graphics::NodeID node) const {
-        _nodeID = node;
-    }
-    graphics::DrawcallObjectPointer GizmoDrawable::getDrawable() const {
-        return _drawcall;
-    }
+       graphics::DescriptorObjects descriptorObjects = {
+            camera_uboDescriptorObject,
+            transform_rboDescriptorObject,
+            drawables_rboDescriptorObject,
+            items_rboDescriptorObject
+       };
+       device->updateDescriptorSet(descriptorSet, descriptorObjects);
+
+       auto pgizmo = &gizmo;
+       auto pipeline = this->_itemPipeline;
+
+       // And now a render callback where we describe the rendering sequence
+       graphics::DrawObjectCallback drawCallback = [pgizmo, descriptorSet, pipeline](const NodeID node, const graphics::CameraPointer& camera, const graphics::SwapchainPointer& swapchain, const graphics::DevicePointer& device, const graphics::BatchPointer& batch) {
+           batch->setPipeline(pipeline);
+           batch->setViewport(camera->getViewportRect());
+           batch->setScissor(camera->getViewportRect());
+
+           batch->bindDescriptorSet(descriptorSet);
+
+           GizmoObjectData odata{ node, 0, 0, 0, pgizmo->getUniforms()->triangleScale };
+           batch->bindPushUniform(1, sizeof(GizmoObjectData), (const uint8_t*)&odata);
+
+           batch->draw(pgizmo->items.size() * 2 * (12 + 12), 0);
+       };
+       gizmo._drawcall = drawCallback;
+   }
 
 } // !namespace graphics

--- a/src/graphics/drawables/GizmoDrawable.cpp
+++ b/src/graphics/drawables/GizmoDrawable.cpp
@@ -129,18 +129,18 @@ namespace graphics
 
         // Assign the Camera UBO just created as the resource of the descriptorSet
         // auto descriptorObjects = descriptorSet->buildDescriptorObjects();
-        graphics::DescriptorObject uboDescriptorObject;
-        uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
-        graphics::DescriptorObject rboDescriptorObject;
-        rboDescriptorObject._buffers.push_back(transform->_transforms_buffer);
+        graphics::DescriptorObject camera_uboDescriptorObject;
+        camera_uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
+        graphics::DescriptorObject transform_rboDescriptorObject;
+        transform_rboDescriptorObject._buffers.push_back(transform->_transforms_buffer);
         graphics::DescriptorObjects descriptorObjects = {
-            uboDescriptorObject,
-            rboDescriptorObject
+            camera_uboDescriptorObject,
+            transform_rboDescriptorObject
         };
         device->updateDescriptorSet(descriptorSet, descriptorObjects);
 
         // And now a render callback where we describe the rendering sequence
-        graphics::DrawObjectCallback drawCallback = [gizmo, descriptorSet, this](const core::mat4x3& transform, const graphics::CameraPointer& camera, const graphics::SwapchainPointer& swapchain, const graphics::DevicePointer& device, const graphics::BatchPointer& batch) {
+        graphics::DrawObjectCallback drawCallback = [gizmo, descriptorSet, this](const NodeID node, const graphics::CameraPointer& camera, const graphics::SwapchainPointer& swapchain, const graphics::DevicePointer& device, const graphics::BatchPointer& batch) {
             batch->setPipeline(this->_pipeline);
             batch->setViewport(camera->getViewportRect());
             batch->setScissor(camera->getViewportRect());
@@ -148,7 +148,7 @@ namespace graphics
             batch->bindDescriptorSet(descriptorSet);
 
             auto uniforms = gizmo->getUniforms();
-            GizmoObjectData odata{ gizmo->nodes.size(), 0, 0, 0, uniforms->triangleScale };
+            GizmoObjectData odata{ node, 0, 0, 0, uniforms->triangleScale };
             batch->bindPushUniform(1, sizeof(GizmoObjectData), (const uint8_t*)&odata);
 
             batch->draw(gizmo->nodes.size() * 8, 0);

--- a/src/graphics/drawables/GizmoDrawable.cpp
+++ b/src/graphics/drawables/GizmoDrawable.cpp
@@ -71,7 +71,8 @@ namespace graphics
         graphics::DescriptorLayouts descriptorLayouts{
             { graphics::DescriptorType::UNIFORM_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
             { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(GizmoObjectData) >> 2},
-            { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 0, 1}, 
+            { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
+            { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 1, 1},
         };
 
         graphics::DescriptorSetLayoutInit descriptorSetLayoutInit{ descriptorLayouts };
@@ -133,9 +134,12 @@ namespace graphics
         camera_uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
         graphics::DescriptorObject transform_rboDescriptorObject;
         transform_rboDescriptorObject._buffers.push_back(transform->_transforms_buffer);
+        graphics::DescriptorObject bound_rboDescriptorObject;
+        bound_rboDescriptorObject._buffers.push_back(transform->_bounds_buffer);
         graphics::DescriptorObjects descriptorObjects = {
             camera_uboDescriptorObject,
-            transform_rboDescriptorObject
+            transform_rboDescriptorObject,
+            bound_rboDescriptorObject
         };
         device->updateDescriptorSet(descriptorSet, descriptorObjects);
 
@@ -151,7 +155,7 @@ namespace graphics
             GizmoObjectData odata{ node, 0, 0, 0, uniforms->triangleScale };
             batch->bindPushUniform(1, sizeof(GizmoObjectData), (const uint8_t*)&odata);
 
-            batch->draw(gizmo->nodes.size() * 8, 0);
+            batch->draw(gizmo->nodes.size() * 2 * (3 + 1 + 12), 0);
         };
         auto drawcall = new graphics::DrawcallObject(drawCallback);
         gizmo->_drawcall = graphics::DrawcallObjectPointer(drawcall);

--- a/src/graphics/drawables/GizmoDrawable.h
+++ b/src/graphics/drawables/GizmoDrawable.h
@@ -1,0 +1,103 @@
+// GizmoDrawable.h 
+//
+// Sam Gateau - October 2020
+// 
+// MIT License
+//
+// Copyright (c) 2020 Sam Gateau
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#pragma once
+
+#include <memory>
+#include <core/math/LinearAlgebra.h>
+#include "dllmain.h"
+
+namespace graphics {
+    class DrawcallObject;
+    using DrawcallObjectPointer = std::shared_ptr<DrawcallObject>;
+    class Device;
+    using DevicePointer = std::shared_ptr<Device>;
+    class Camera;
+    using CameraPointer = std::shared_ptr<Camera>;
+    class Buffer;
+    using BufferPointer = std::shared_ptr<Buffer>;
+    class PipelineState;
+    using PipelineStatePointer = std::shared_ptr<PipelineState>;
+
+    class GizmoDrawable;
+    using GizmoDrawablePointer = std::shared_ptr<GizmoDrawable>;
+
+    struct VISUALIZATION_API GizmoDrawableUniforms {
+        float triangleScale{ 0.05f };
+    };
+    using GizmoDrawableUniformsPointer = std::shared_ptr<GizmoDrawableUniforms>;
+
+    class VISUALIZATION_API GizmoDrawableFactory {
+    public:
+        GizmoDrawableFactory();
+        ~GizmoDrawableFactory();
+
+        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
+        void allocateGPUShared(const graphics::DevicePointer& device);
+
+        // Create GizmoDrawable for a given Gizmo document, building the gpu vertex buffer
+        graphics::GizmoDrawable* createGizmoDrawable(const graphics::DevicePointer& device);
+
+        // Create Drawcall object drawing the GizmoDrawable in the rendering context
+        graphics::DrawcallObjectPointer allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::CameraPointer& camera,
+            const graphics::GizmoDrawablePointer& pointcloudDrawable);
+
+        // Read / write shared uniforms
+        const GizmoDrawableUniforms& getUniforms() const { return (*_sharedUniforms); }
+        GizmoDrawableUniforms& editUniforms() { return (*_sharedUniforms); }
+
+    protected:
+        GizmoDrawableUniformsPointer _sharedUniforms;
+        graphics::PipelineStatePointer _pipeline;
+    };
+    using GizmoDrawableFactoryPointer = std::shared_ptr< GizmoDrawableFactory>;
+
+
+    /*
+    const pico::DrawcallObjectPointer& getDrawable(const GizmoDrawable& x) {
+        return x.getDrawable();
+    }*/
+    class VISUALIZATION_API GizmoDrawable {
+    public:
+        GizmoDrawable();
+        ~GizmoDrawable();
+        
+        graphics::DrawcallObjectPointer getDrawable() const;
+
+        void swapUniforms(const GizmoDrawableUniformsPointer& uniforms) { _uniforms = uniforms; }
+        const GizmoDrawableUniformsPointer& getUniforms() const { return _uniforms; }
+
+    protected:
+        friend class GizmoDrawableFactory;
+
+        GizmoDrawableUniformsPointer _uniforms;
+        graphics::DrawcallObjectPointer _drawcall;
+        core::mat4x3 _transform;
+        core::Bounds _bounds;
+    };
+
+
+} // !namespace graphics

--- a/src/graphics/drawables/GizmoDrawable.h
+++ b/src/graphics/drawables/GizmoDrawable.h
@@ -30,11 +30,15 @@
 #include <core/math/LinearAlgebra.h>
 #include "dllmain.h"
 
+#include <render/Scene.h>
+
 namespace graphics {
     class DrawcallObject;
     using DrawcallObjectPointer = std::shared_ptr<DrawcallObject>;
     class Device;
     using DevicePointer = std::shared_ptr<Device>;
+    class TransformTreeGPU;
+    using TransformTreeGPUPointer = std::shared_ptr<TransformTreeGPU>;
     class Camera;
     using CameraPointer = std::shared_ptr<Camera>;
     class Buffer;
@@ -62,7 +66,7 @@ namespace graphics {
         graphics::GizmoDrawable* createGizmoDrawable(const graphics::DevicePointer& device);
 
         // Create Drawcall object drawing the GizmoDrawable in the rendering context
-        graphics::DrawcallObjectPointer allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::CameraPointer& camera,
+        graphics::DrawcallObjectPointer allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::TransformTreeGPUPointer& transform, const graphics::CameraPointer& camera,
             const graphics::GizmoDrawablePointer& pointcloudDrawable);
 
         // Read / write shared uniforms
@@ -86,6 +90,10 @@ namespace graphics {
         ~GizmoDrawable();
         
         graphics::DrawcallObjectPointer getDrawable() const;
+        void setNode(graphics::NodeID node) const;
+        graphics::NodeID getNode() const { return _nodeID; }
+
+        std::vector<NodeID> nodes; 
 
         void swapUniforms(const GizmoDrawableUniformsPointer& uniforms) { _uniforms = uniforms; }
         const GizmoDrawableUniformsPointer& getUniforms() const { return _uniforms; }
@@ -93,10 +101,9 @@ namespace graphics {
     protected:
         friend class GizmoDrawableFactory;
 
+        mutable graphics::NodeID _nodeID { 0 };
         GizmoDrawableUniformsPointer _uniforms;
         graphics::DrawcallObjectPointer _drawcall;
-        core::mat4x3 _transform;
-        core::Bounds _bounds;
     };
 
 

--- a/src/graphics/drawables/GizmoNode_vert.hlsl
+++ b/src/graphics/drawables/GizmoNode_vert.hlsl
@@ -1,0 +1,175 @@
+#define mat43 float4x3
+
+//
+// Transform API
+//
+struct Transform {
+    float4 _right_upX;
+    float4 _upYZ_backXY;
+    float4 _backZ_ori;
+
+    float3 row_x() { return float3(_right_upX.x, _right_upX.w, _upYZ_backXY.z); }
+    float3 row_y() { return float3(_right_upX.y, _upYZ_backXY.x, _upYZ_backXY.w); }
+    float3 row_z() { return float3(_right_upX.z, _upYZ_backXY.y, _backZ_ori.x); }
+
+    float3 col_x() { return _right_upX.xyz; }
+    float3 col_y() { return float3(_right_upX.w, _upYZ_backXY.xy); }
+    float3 col_z() { return float3(_upYZ_backXY.zw, _backZ_ori.x); }
+    float3 col_w() { return _backZ_ori.yzw; }
+};
+
+float3 rotateFrom(const Transform mat, const float3 d) {
+    return float3(dot(mat.row_x(), d), dot(mat.row_y(), d), dot(mat.row_z(), d));
+}
+float3 rotateTo(const Transform mat, const float3 d) {
+    return float3(dot(mat.col_x(), d), dot(mat.col_y(), d), dot(mat.col_z(), d));
+}
+
+float3 transformTo(const Transform mat, const float3 p) {
+    return rotateTo(mat, p - mat.col_w());
+}
+float3 transformFrom(const Transform mat, const float3 p) {
+    return rotateFrom(mat, p) + mat.col_w();
+}
+
+//
+// Projection API
+// 
+struct Projection {
+    float4 _aspectRatio_sensorHeight_focal_far;
+    float4 _ortho_enabled_height_near_far;
+
+    float aspectRatio() { return (_aspectRatio_sensorHeight_focal_far.x); }
+    float sensorHeight() { return (_aspectRatio_sensorHeight_focal_far.y); }
+    float focal() { return (_aspectRatio_sensorHeight_focal_far.z); }
+    float persFar() { return (_aspectRatio_sensorHeight_focal_far.w); }
+
+    bool isOrtho() { return (_ortho_enabled_height_near_far.x > 0.0); }
+    float orthoHeight() { return (_ortho_enabled_height_near_far.y); }
+    float orthoNear() { return (_ortho_enabled_height_near_far.z); }
+    float orthoFar() { return (_ortho_enabled_height_near_far.w); }
+};
+
+
+float4 clipFromEyeSpace(float aspectRatio, float sensorHeight, float focal, float pfar, float3 eyePos) {
+    float ez = -eyePos.z;
+    float pnear = focal;
+    // Infinite far inverted Z
+    // float b = 0.0f; //lim at far  infinite of  pnear / (pnear- pfar);;
+    // float a = pnear; // lim at far infinite of - pfar * pnear / (pnear - pfar);
+    float4 clipPos;
+    clipPos.w = ez;
+    clipPos.z = pnear;
+    // float depthBuffer = z/w = a * (1/ez) + b; 
+    clipPos.x = eyePos.x * pnear * 2.0 / (sensorHeight * aspectRatio);
+    clipPos.y = eyePos.y * pnear * 2.0 / (sensorHeight);
+    return clipPos;
+}
+
+float4 orthoClipFromEyeSpace(float aspectRatio, float sensorHeight, float pnear, float pfar, const float3 eyePos) {
+    float4 clipPos;
+    clipPos.w = 1.0f;
+    clipPos.z = (pfar - (-eyePos.z)) / (pfar - pnear);
+    clipPos.x = eyePos.x * 2.0f / (sensorHeight * aspectRatio);
+    clipPos.y = eyePos.y * 2.0f / (sensorHeight);
+    return clipPos;
+}
+
+float4 clipFromEyeSpace(Projection proj, float3 eyePos) {
+    if (proj.isOrtho()) {
+        return orthoClipFromEyeSpace(proj.aspectRatio(), proj.orthoHeight(), proj.orthoNear(), proj.orthoFar(), eyePos);
+    }
+    else {
+        return clipFromEyeSpace(proj.aspectRatio(), proj.sensorHeight(), proj.focal(), proj.persFar(), eyePos);
+    }
+}
+
+// Camera buffer
+cbuffer UniformBlock0 : register(b0) {
+    //float4x3 _view;
+    Transform _view;
+    Projection _projection;
+    float4 _viewport;
+};
+
+
+float3 eyeFromWorldSpace(Transform view, float3 worldPos) {
+    return transformTo(view, worldPos);
+}
+
+float3 worldFromObjectSpace(Transform model, float3 objPos) {
+    return transformFrom(model, objPos);
+}
+
+float3 objectFromWorldSpaceDir(Transform model, float3 worldDir) {
+    return rotateTo(model, worldDir);
+}
+
+
+//
+// Transform Tree
+//
+StructuredBuffer<Transform>  tree_transforms : register(t0);
+
+Transform node_getTransform(int nodeID) {
+    return tree_transforms[2 * nodeID];
+}
+Transform node_getWorldTransform(int nodeID) {
+    return tree_transforms[2 * nodeID + 1];
+}
+
+cbuffer UniformBlock1 : register(b1) {
+    int   _nodeID;
+}
+
+
+struct VertexPosColor
+{
+    float3 Position : POSITION;
+    //  float3 Normal : NORMAL;
+    float4 Color : COLOR;
+};
+
+struct VertexShaderOutput
+{
+    float4 Color    : COLOR;
+    float4 Position : SV_Position;
+};
+
+VertexShaderOutput main(uint ivid : SV_VertexID)
+{
+    VertexShaderOutput OUT;
+
+    const int transform_num_edges = 3;
+    const int node_num_edges = 1;
+    const int num_edges = transform_num_edges + node_num_edges;
+
+    uint vid = ivid % (2 * num_edges);
+    uint nodeid = ivid / (2 * num_edges);
+    uint svid = vid % 2;
+    uint lid = vid / 2;
+
+    float3 position = float3(0.0, 0.0, 0.0);
+    float3 color = float3(1.0, 1.0, 1.0);
+
+    Transform _model = node_getWorldTransform(nodeid);
+    Transform _modelLocal = node_getTransform(nodeid);
+
+    if (lid < (transform_num_edges)) {
+        position = float(svid) * float3(float(lid == 0), float(lid == 1), float(lid == 2));
+        color = float3(float(lid == 0), float(lid == 1), float(lid == 2));
+    }
+    else if (lid < (transform_num_edges + node_num_edges)) {
+        position = float(svid) * objectFromWorldSpaceDir(_modelLocal, -_modelLocal.col_w());
+    }
+
+    position = worldFromObjectSpace(_model, position);
+    float3 eyePosition = eyeFromWorldSpace(_view, position);
+    float4 clipPos = clipFromEyeSpace(_projection, eyePosition);
+
+    OUT.Position = clipPos;
+    OUT.Color = float4(color, 1.0f);
+ 
+    return OUT;
+}
+

--- a/src/graphics/drawables/Gizmo_frag.hlsl
+++ b/src/graphics/drawables/Gizmo_frag.hlsl
@@ -1,0 +1,9 @@
+struct PixelShaderInput
+{
+    float4 Color    : COLOR;
+};
+
+float4 main(PixelShaderInput IN) : SV_Target
+{
+    return IN.Color;
+}

--- a/src/graphics/drawables/Gizmo_vert.hlsl
+++ b/src/graphics/drawables/Gizmo_vert.hlsl
@@ -1,0 +1,143 @@
+#define mat43 float4x3
+
+struct View {
+    float4 _right_upX;
+    float4 _upYZ_backXY;
+    float4 _backZ_eye;
+
+    float3 right() { return _right_upX.xyz; }
+    float3 up() { return float3(_right_upX.w, _upYZ_backXY.xy); }
+    float3 back() { return float3(_upYZ_backXY.zw, _backZ_eye.x); }
+    float3 eye() { return _backZ_eye.yzw; }
+};
+
+struct Projection {
+    float4 _aspectRatio_sensorHeight_focal_far;
+    float4 _ortho_enabled_height_near_far;
+
+    float aspectRatio() { return (_aspectRatio_sensorHeight_focal_far.x); }
+    float sensorHeight() { return (_aspectRatio_sensorHeight_focal_far.y); }
+    float focal() { return (_aspectRatio_sensorHeight_focal_far.z); }
+    float persFar() { return (_aspectRatio_sensorHeight_focal_far.w); }
+
+    bool isOrtho() { return (_ortho_enabled_height_near_far.x > 0.0); }
+    float orthoHeight() { return (_ortho_enabled_height_near_far.y); }
+    float orthoNear() { return (_ortho_enabled_height_near_far.z); }
+    float orthoFar() { return (_ortho_enabled_height_near_far.w); }
+};
+
+
+float4 clipFromEyeSpace(float aspectRatio, float sensorHeight, float focal, float pfar, float3 eyePos) {
+    float ez = -eyePos.z;
+    float pnear = focal;
+    // Infinite far inverted Z
+    // float b = 0.0f; //lim at far  infinite of  pnear / (pnear- pfar);;
+    // float a = pnear; // lim at far infinite of - pfar * pnear / (pnear - pfar);
+    float4 clipPos;
+    clipPos.w = ez;
+    clipPos.z = pnear;
+    // float depthBuffer = z/w = a * (1/ez) + b; 
+    clipPos.x = eyePos.x * pnear * 2.0 / (sensorHeight * aspectRatio);
+    clipPos.y = eyePos.y * pnear * 2.0 / (sensorHeight);
+    return clipPos;
+}
+
+float4 orthoClipFromEyeSpace(float aspectRatio, float sensorHeight, float pnear, float pfar, const float3 eyePos) {
+    float4 clipPos;
+    clipPos.w = 1.0f;
+    clipPos.z = (pfar - (-eyePos.z)) / (pfar - pnear);
+    clipPos.x = eyePos.x * 2.0f / (sensorHeight * aspectRatio);
+    clipPos.y = eyePos.y * 2.0f / (sensorHeight);
+    return clipPos;
+}
+
+float4 clipFromEyeSpace(Projection proj, float3 eyePos) {
+    if (proj.isOrtho()) {
+        return orthoClipFromEyeSpace(proj.aspectRatio(), proj.orthoHeight(), proj.orthoNear(), proj.orthoFar(), eyePos);
+    } else {
+        return clipFromEyeSpace(proj.aspectRatio(), proj.sensorHeight(), proj.focal(), proj.persFar(), eyePos);
+    }
+}
+
+cbuffer UniformBlock0 : register(b0) {
+    //float4x3 _view;
+    View _view;
+    Projection _projection;
+    float4 _viewport;
+};
+
+
+float3 eyeFromWorldSpace(float3 right, float3 up, float3 back, float3 eye, float3 worldPos) {
+    // TranslationInv
+    float3 eyeCenteredPos = worldPos - eye;
+    return eyeCenteredPos;
+    // RotationInv
+    return float3(dot(right, eyeCenteredPos), dot(up, eyeCenteredPos), dot(back, eyeCenteredPos));
+}
+
+float3 eyeFromWorldSpace(View view, float3 worldPos) {
+    // TranslationInv
+    float3 eyeCenteredPos = worldPos - view.eye();
+    //  return eyeCenteredPos;
+      // RotationInv
+    return float3(dot(view.right(), eyeCenteredPos), dot(view.up(), eyeCenteredPos), dot(view.back(), eyeCenteredPos));
+}
+
+struct Transform {
+    float4 _right_upX;
+    float4 _upYZ_backXY;
+    float4 _backZ_ori;
+
+    float3 right() { return _right_upX.xyz; }
+    float3 up() { return float3(_right_upX.w, _upYZ_backXY.xy); }
+    float3 back() { return float3(_upYZ_backXY.zw, _backZ_ori.x); }
+
+    float3 invX() { return float3(_right_upX.x, _right_upX.w, _upYZ_backXY.z); }
+    float3 invY() { return float3(_right_upX.y, _upYZ_backXY.x, _upYZ_backXY.w); }
+    float3 invZ() { return float3(_right_upX.z, _upYZ_backXY.y, _backZ_ori.x); }
+
+    float3 ori() { return _backZ_ori.yzw; }
+};
+
+cbuffer UniformBlock1 : register(b1) {
+    Transform _model;
+}
+
+float3 worldFromObjectSpace(Transform model, float3 objPos) {
+    float3 rotatedPos = float3(dot(model.invX(), objPos), dot(model.invY(), objPos), dot(model.invZ(), objPos));
+    // TranslationInv
+    return  rotatedPos + model.ori();
+}
+
+struct VertexPosColor
+{
+    float3 Position : POSITION;
+    //  float3 Normal : NORMAL;
+    float4 Color : COLOR;
+};
+
+struct VertexShaderOutput
+{
+    float4 Color    : COLOR;
+    float4 Position : SV_Position;
+};
+
+VertexShaderOutput main(uint vid : SV_VertexID)
+{
+    VertexShaderOutput OUT;
+
+    uint pid = vid % 2;
+    uint aid = vid / 2;
+
+    float3 position = float(pid) * float3(float(aid == 0), float(aid == 1), float(aid == 2));
+
+    position = worldFromObjectSpace(_model, position);
+    float3 eyePosition = eyeFromWorldSpace(_view, position);
+    float4 clipPos = clipFromEyeSpace(_projection, eyePosition);
+
+    OUT.Position = clipPos;
+    OUT.Color = float4(float(aid == 0), float(aid == 1), float(aid == 2), 1.0f);
+
+    return OUT;
+}
+

--- a/src/graphics/drawables/PointCloud_vert.hlsl
+++ b/src/graphics/drawables/PointCloud_vert.hlsl
@@ -1,16 +1,40 @@
 #define mat43 float4x3
 
-struct View {
+//
+// Transform API
+//
+struct Transform {
     float4 _right_upX;
     float4 _upYZ_backXY;
-    float4 _backZ_eye;
+    float4 _backZ_ori;
 
-    float3 right() { return _right_upX.xyz; }
-    float3 up() { return float3(_right_upX.w, _upYZ_backXY.xy); }
-    float3 back() { return float3(_upYZ_backXY.zw, _backZ_eye.x); }
-    float3 eye() { return _backZ_eye.yzw; }
+    float3 row_x() { return float3(_right_upX.x, _right_upX.w, _upYZ_backXY.z); }
+    float3 row_y() { return float3(_right_upX.y, _upYZ_backXY.x, _upYZ_backXY.w); }
+    float3 row_z() { return float3(_right_upX.z, _upYZ_backXY.y, _backZ_ori.x); }
+
+    float3 col_x() { return _right_upX.xyz; }
+    float3 col_y() { return float3(_right_upX.w, _upYZ_backXY.xy); }
+    float3 col_z() { return float3(_upYZ_backXY.zw, _backZ_ori.x); }
+    float3 col_w() { return _backZ_ori.yzw; }
 };
 
+float3 rotateFrom(const Transform mat, const float3 d) {
+    return float3(dot(mat.row_x(), d), dot(mat.row_y(), d), dot(mat.row_z(), d));
+}
+float3 rotateTo(const Transform mat, const float3 d) {
+    return float3(dot(mat.col_x(), d), dot(mat.col_y(), d), dot(mat.col_z(), d));
+}
+
+float3 transformTo(const Transform mat, const float3 p) {
+    return rotateTo(mat, p - mat.col_w());
+}
+float3 transformFrom(const Transform mat, const float3 p) {
+    return rotateFrom(mat, p) + mat.col_w();
+}
+
+//
+// Projection API
+// 
 struct Projection {
     float4 _aspectRatio_sensorHeight_focal_far;
     float4 _ortho_enabled_height_near_far;
@@ -54,63 +78,51 @@ float4 orthoClipFromEyeSpace(float aspectRatio, float sensorHeight, float pnear,
 float4 clipFromEyeSpace(Projection proj, float3 eyePos) {
     if (proj.isOrtho()) {
         return orthoClipFromEyeSpace(proj.aspectRatio(), proj.orthoHeight(), proj.orthoNear(), proj.orthoFar(), eyePos);
-    } else {
+    }
+    else {
         return clipFromEyeSpace(proj.aspectRatio(), proj.sensorHeight(), proj.focal(), proj.persFar(), eyePos);
     }
 }
 
+// Camera buffer
 cbuffer UniformBlock0 : register(b0) {
     //float4x3 _view;
-    View _view;
+    Transform _view;
     Projection _projection;
     float4 _viewport;
 };
 
 
-float3 eyeFromWorldSpace(float3 right, float3 up, float3 back, float3 eye, float3 worldPos) {
-    // TranslationInv
-    float3 eyeCenteredPos = worldPos - eye;
-    return eyeCenteredPos;
-    // RotationInv
-    return float3(dot(right, eyeCenteredPos), dot(up, eyeCenteredPos), dot(back, eyeCenteredPos));
+float3 eyeFromWorldSpace(Transform view, float3 worldPos) {
+    return transformTo(view, worldPos);
 }
 
-float3 eyeFromWorldSpace(View view, float3 worldPos) {
-    // TranslationInv
-    float3 eyeCenteredPos = worldPos - view.eye();
-    //  return eyeCenteredPos;
-      // RotationInv
-    return float3(dot(view.right(), eyeCenteredPos), dot(view.up(), eyeCenteredPos), dot(view.back(), eyeCenteredPos));
+float3 worldFromObjectSpace(Transform model, float3 objPos) {
+    return transformFrom(model, objPos);
 }
 
-struct Transform {
-    float4 _right_upX;
-    float4 _upYZ_backXY;
-    float4 _backZ_ori;
+float3 objectFromWorldSpaceDir(Transform model, float3 worldDir) {
+    return rotateTo(model, worldDir);
+}
 
-    float3 right() { return _right_upX.xyz; }
-    float3 up() { return float3(_right_upX.w, _upYZ_backXY.xy); }
-    float3 back() { return float3(_upYZ_backXY.zw, _backZ_ori.x); }
+//
+// Transform Tree
+//
+StructuredBuffer<Transform>  tree_transforms : register(t0);
 
-    float3 invX() { return float3(_right_upX.x, _right_upX.w, _upYZ_backXY.z); }
-    float3 invY() { return float3(_right_upX.y, _upYZ_backXY.x, _upYZ_backXY.w); }
-    float3 invZ() { return float3(_right_upX.z, _upYZ_backXY.y, _backZ_ori.x); }
-
-    float3 ori() { return _backZ_ori.yzw; }
-};
+Transform node_getTransform(int nodeID) {
+    return tree_transforms[2 * nodeID];
+}
+Transform node_getWorldTransform(int nodeID) {
+    return tree_transforms[2 * nodeID + 1];
+}
 
 cbuffer UniformBlock1 : register(b1) {
-    Transform _model;
+    int4   _instance;
     float _spriteSize;
     float _perspectiveSpriteX;
     float _perspectiveDepth;
     float _showPerspectiveDepthPlane;
-}
-
-float3 worldFromObjectSpace(Transform model, float3 objPos) {
-    float3 rotatedPos = float3(dot(model.invX(), objPos), dot(model.invY(), objPos), dot(model.invZ(), objPos));
-    // TranslationInv
-    return  rotatedPos + model.ori();
 }
 
 /*struct VertexPosColor
@@ -127,7 +139,7 @@ struct PointPosColor {
     uint  color;
 };
 
-StructuredBuffer<PointPosColor>  BufferIn : register(t0);
+StructuredBuffer<PointPosColor>  BufferIn : register(t1);
 
 struct VertexShaderOutput
 {
@@ -148,6 +160,8 @@ VertexShaderOutput main(uint vidT : SV_VertexID)
     float g = INT8_TO_NF * (float)((color >> 8) & 0xFF);
     float b = INT8_TO_NF * (float)((color >> 16) & 0xFF);
     float3 position = float3(BufferIn[vid].x, BufferIn[vid].y, BufferIn[vid].z);
+
+    Transform _model = node_getWorldTransform(_instance.x);
 
     position = worldFromObjectSpace(_model, position);
     float3 eyePosition = eyeFromWorldSpace(_view, position);

--- a/src/graphics/drawables/PointcloudDrawable.cpp
+++ b/src/graphics/drawables/PointcloudDrawable.cpp
@@ -221,7 +221,9 @@ namespace graphics
     PointCloudDrawable::~PointCloudDrawable() {
 
     }
+    void PointCloudDrawable::setNode(graphics::NodeID node) const {
 
+    }
     graphics::DrawcallObjectPointer PointCloudDrawable::getDrawable() const {
         return _drawcall;
     }

--- a/src/graphics/drawables/PointcloudDrawable.h
+++ b/src/graphics/drawables/PointcloudDrawable.h
@@ -30,14 +30,13 @@
 #include <core/math/LinearAlgebra.h>
 #include "dllmain.h"
 #include <render/Scene.h>
+#include <render/Drawable.h>
 
 namespace document {
     class PointCloud;
     using PointCloudPointer = std::shared_ptr<PointCloud>;
 }
 namespace graphics {
-    class DrawcallObject;
-    using DrawcallObjectPointer = std::shared_ptr<DrawcallObject>;
     class Device;
     using DevicePointer = std::shared_ptr<Device>;
     class Camera;
@@ -89,8 +88,8 @@ namespace graphics {
         graphics::PointCloudDrawable* createPointCloudDrawable(const graphics::DevicePointer& device, const document::PointCloudPointer& pointcloud);
 
         // Create Drawcall object drawing the PointCloudDrawable in the rendering context
-        graphics::DrawcallObjectPointer allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::TransformTreeGPUPointer& transform, const graphics::CameraPointer& camera,
-               const graphics::PointCloudDrawablePointer& pointcloudDrawable);
+        void allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::ScenePointer& scene, const graphics::CameraPointer& camera,
+               graphics::PointCloudDrawable& pointcloudDrawable);
     
         // Read / write shared uniforms
         const PointCloudDrawableUniforms& getUniforms() const { return (*_sharedUniforms); }
@@ -102,33 +101,28 @@ namespace graphics {
     };
     using PointCloudDrawableFactoryPointer = std::shared_ptr< PointCloudDrawableFactory>;
     
-    /*
-    PointCloudDrawable is a render item payload.
-    const graphics::DrawcallObjectPointer& getDrawable(const PointCloudDrawable& x) {
-        return x.getDrawable();
-    }*/
+
     class VISUALIZATION_API PointCloudDrawable {
     public:
         PointCloudDrawable();
         ~PointCloudDrawable();
-
-        void setNode(graphics::NodeID node) const;
-
-        graphics::DrawcallObjectPointer getDrawable() const;
 
         void swapUniforms(const PointCloudDrawableUniformsPointer& uniforms) { _uniforms = uniforms; }
         const PointCloudDrawableUniformsPointer& getUniforms() const { return _uniforms; }
 
         graphics::BufferPointer getVertexBuffer() const { return _vertexBuffer; }
 
+        core::aabox3 getBound() const { return _bounds.toBox(); }
+        DrawObjectCallback getDrawcall() const { return _drawcall; }
+
     protected:
         friend class PointCloudDrawableFactory;
 
         PointCloudDrawableUniformsPointer _uniforms;
-        graphics::DrawcallObjectPointer _drawcall;
         graphics::BufferPointer _vertexBuffer;
         core::mat4x3 _transform;
         core::Bounds _bounds;
+        DrawObjectCallback _drawcall;
     };
 
 

--- a/src/graphics/drawables/PointcloudDrawable.h
+++ b/src/graphics/drawables/PointcloudDrawable.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <core/math/LinearAlgebra.h>
 #include "dllmain.h"
+#include <render/Scene.h>
 
 namespace document {
     class PointCloud;
@@ -110,6 +111,8 @@ namespace graphics {
     public:
         PointCloudDrawable();
         ~PointCloudDrawable();
+
+        void setNode(graphics::NodeID node) const;
 
         graphics::DrawcallObjectPointer getDrawable() const;
 

--- a/src/graphics/drawables/PointcloudDrawable.h
+++ b/src/graphics/drawables/PointcloudDrawable.h
@@ -89,7 +89,7 @@ namespace graphics {
         graphics::PointCloudDrawable* createPointCloudDrawable(const graphics::DevicePointer& device, const document::PointCloudPointer& pointcloud);
 
         // Create Drawcall object drawing the PointCloudDrawable in the rendering context
-        graphics::DrawcallObjectPointer allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::CameraPointer& camera,
+        graphics::DrawcallObjectPointer allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::TransformTreeGPUPointer& transform, const graphics::CameraPointer& camera,
                const graphics::PointCloudDrawablePointer& pointcloudDrawable);
     
         // Read / write shared uniforms

--- a/src/graphics/drawables/TriangleSoupDrawable.cpp
+++ b/src/graphics/drawables/TriangleSoupDrawable.cpp
@@ -237,7 +237,10 @@ namespace graphics
     TriangleSoupDrawable::~TriangleSoupDrawable() {
 
     }
-       
+    void TriangleSoupDrawable::setNode(graphics::NodeID node) const {
+
+    }
+
     graphics::DrawcallObjectPointer TriangleSoupDrawable::getDrawable() const {
         return _drawcall;
     }

--- a/src/graphics/drawables/TriangleSoupDrawable.cpp
+++ b/src/graphics/drawables/TriangleSoupDrawable.cpp
@@ -60,7 +60,7 @@ namespace graphics
 
     // Custom data uniforms
     struct TSObjectData {
-        core::mat4x3 transform;
+        core::ivec4 instance { 0 };
         uint32_t numVertices{ 0 };
         uint32_t numIndices{ 0 };
         uint32_t stride{ 0 };
@@ -75,6 +75,8 @@ namespace graphics
             { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(TSObjectData) >> 2},
             { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
             { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 1, 1},
+            { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 2, 1},
+
         };
 
         graphics::DescriptorSetLayoutInit descriptorSetLayoutInit{ descriptorLayouts };
@@ -171,7 +173,6 @@ namespace graphics
         triangleSoupDrawable->_vertexBuffer = vbresourceBuffer;
         triangleSoupDrawable->_indexBuffer = ibresourceBuffer;
         triangleSoupDrawable->_bounds = mesh->_bounds;
-        triangleSoupDrawable->_transform = triangleSoup->_transform;
 
         // Create the triangle soup drawable using the shared uniforms of the factory
         triangleSoupDrawable->_uniforms = _sharedUniforms;
@@ -180,7 +181,7 @@ namespace graphics
     }
 
     graphics::DrawcallObjectPointer TriangleSoupDrawableFactory::allocateDrawcallObject(const graphics::DevicePointer& device,
-        const graphics::CameraPointer& camera, const graphics::TriangleSoupDrawablePointer& triangleSoup)
+        const graphics::TransformTreeGPUPointer& transform, const graphics::CameraPointer& camera, const graphics::TriangleSoupDrawablePointer& triangleSoup)
     {
         // It s time to create a descriptorSet that matches the expected pipeline descriptor set
         // then we will assign a uniform buffer in it
@@ -191,14 +192,16 @@ namespace graphics
 
         // Assign the Camera UBO just created as the resource of the descriptorSet
         // auto descriptorObjects = descriptorSet->buildDescriptorObjects();
-        graphics::DescriptorObject uboDescriptorObject;
-        uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
+        graphics::DescriptorObject camera_uboDescriptorObject;
+        camera_uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
+        graphics::DescriptorObject transform_rboDescriptorObject;
+        transform_rboDescriptorObject._buffers.push_back(transform->_transforms_buffer);
         graphics::DescriptorObject vb_rboDescriptorObject;
         vb_rboDescriptorObject._buffers.push_back(triangleSoup->getVertexBuffer());
         graphics::DescriptorObject ib_rboDescriptorObject;
         ib_rboDescriptorObject._buffers.push_back(triangleSoup->getIndexBuffer());
         graphics::DescriptorObjects descriptorObjects = {
-            uboDescriptorObject, vb_rboDescriptorObject, ib_rboDescriptorObject
+            camera_uboDescriptorObject, transform_rboDescriptorObject, vb_rboDescriptorObject, ib_rboDescriptorObject
         };
         device->updateDescriptorSet(descriptorSet, descriptorObjects);
 
@@ -208,7 +211,12 @@ namespace graphics
         auto vertexStride = triangleSoup->getVertexBuffer()->_init.structStride;
 
         // And now a render callback where we describe the rendering sequence
-        graphics::DrawObjectCallback drawCallback = [triangleSoup, descriptorSet, numVertices, numIndices, vertexStride, this](const core::mat4x3& transform, const graphics::CameraPointer& camera, const graphics::SwapchainPointer& swapchain, const graphics::DevicePointer& device, const graphics::BatchPointer& batch) {
+        graphics::DrawObjectCallback drawCallback = [triangleSoup, descriptorSet, numVertices, numIndices, vertexStride, this](
+            const NodeID node,
+            const graphics::CameraPointer& camera, 
+            const graphics::SwapchainPointer& swapchain, 
+            const graphics::DevicePointer& device, 
+            const graphics::BatchPointer& batch) {
             batch->setPipeline(this->_pipeline);
             batch->setViewport(camera->getViewportRect());
             batch->setScissor(camera->getViewportRect());
@@ -217,14 +225,13 @@ namespace graphics
             batch->bindDescriptorSet(descriptorSet);
 
             auto uniforms = triangleSoup->getUniforms();
-            TSObjectData odata{ transform, numVertices, numIndices, vertexStride, uniforms->triangleScale };
+            TSObjectData odata{ { (int32_t)node }, numVertices, numIndices, vertexStride, uniforms->triangleScale };
             batch->bindPushUniform(1, sizeof(TSObjectData), (const uint8_t*)&odata);
 
             batch->draw(numIndices, 0);
         };
         auto drawcall = new graphics::DrawcallObject(drawCallback);
         drawcall->_bounds = triangleSoup->_bounds;
-        drawcall->_transform = triangleSoup->_transform;
         triangleSoup->_drawcall = graphics::DrawcallObjectPointer(drawcall);
 
         return triangleSoup->_drawcall;

--- a/src/graphics/drawables/TriangleSoupDrawable.h
+++ b/src/graphics/drawables/TriangleSoupDrawable.h
@@ -67,7 +67,7 @@ namespace graphics {
         graphics::TriangleSoupDrawable* createTriangleSoupDrawable(const graphics::DevicePointer& device, const document::TriangleSoupPointer& pointcloud);
 
         // Create Drawcall object drawing the TriangleSoupDrawable in the rendering context
-        graphics::DrawcallObjectPointer allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::CameraPointer& camera,
+        graphics::DrawcallObjectPointer allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::TransformTreeGPUPointer& transform, const graphics::CameraPointer& camera,
             const graphics::TriangleSoupDrawablePointer& pointcloudDrawable);
 
         // Read / write shared uniforms
@@ -108,7 +108,6 @@ namespace graphics {
         graphics::DrawcallObjectPointer _drawcall;
         graphics::BufferPointer _vertexBuffer;
         graphics::BufferPointer _indexBuffer;
-        core::mat4x3 _transform;
         core::Bounds _bounds;
     };
 

--- a/src/graphics/drawables/TriangleSoupDrawable.h
+++ b/src/graphics/drawables/TriangleSoupDrawable.h
@@ -30,14 +30,13 @@
 #include <core/math/LinearAlgebra.h>
 #include "dllmain.h"
 #include <render/Scene.h>
+#include <render/Drawable.h>
 
 namespace document {
     class TriangleSoup;
     using TriangleSoupPointer = std::shared_ptr<TriangleSoup>;
 }
 namespace graphics {
-    class DrawcallObject;
-    using DrawcallObjectPointer = std::shared_ptr<DrawcallObject>;
     class Device;
     using DevicePointer = std::shared_ptr<Device>;
     class Camera;
@@ -67,8 +66,8 @@ namespace graphics {
         graphics::TriangleSoupDrawable* createTriangleSoupDrawable(const graphics::DevicePointer& device, const document::TriangleSoupPointer& pointcloud);
 
         // Create Drawcall object drawing the TriangleSoupDrawable in the rendering context
-        graphics::DrawcallObjectPointer allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::TransformTreeGPUPointer& transform, const graphics::CameraPointer& camera,
-            const graphics::TriangleSoupDrawablePointer& pointcloudDrawable);
+        void allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::ScenePointer& scene, const graphics::CameraPointer& camera,
+            graphics::TriangleSoupDrawable& pointcloudDrawable);
 
         // Read / write shared uniforms
         const TriangleSoupDrawableUniforms& getUniforms() const { return (*_sharedUniforms); }
@@ -89,10 +88,6 @@ namespace graphics {
     public:
         TriangleSoupDrawable();
         ~TriangleSoupDrawable();
- 
-        void setNode(graphics::NodeID node) const;
-
-        graphics::DrawcallObjectPointer getDrawable() const;
 
         void swapUniforms(const TriangleSoupDrawableUniformsPointer& uniforms) { _uniforms = uniforms; }
         const TriangleSoupDrawableUniformsPointer& getUniforms() const { return _uniforms; }
@@ -100,15 +95,18 @@ namespace graphics {
         graphics::BufferPointer getVertexBuffer() const { return _vertexBuffer; }
         graphics::BufferPointer getIndexBuffer() const { return _indexBuffer; }
 
+        core::aabox3 getBound() const { return _bounds.toBox(); }
+        DrawObjectCallback getDrawcall() const { return _drawcall; }
 
     protected:
         friend class TriangleSoupDrawableFactory;
 
         TriangleSoupDrawableUniformsPointer _uniforms;
-        graphics::DrawcallObjectPointer _drawcall;
         graphics::BufferPointer _vertexBuffer;
         graphics::BufferPointer _indexBuffer;
         core::Bounds _bounds;
+        DrawObjectCallback _drawcall;
+
     };
 
 

--- a/src/graphics/drawables/TriangleSoupDrawable.h
+++ b/src/graphics/drawables/TriangleSoupDrawable.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <core/math/LinearAlgebra.h>
 #include "dllmain.h"
+#include <render/Scene.h>
 
 namespace document {
     class TriangleSoup;
@@ -88,7 +89,9 @@ namespace graphics {
     public:
         TriangleSoupDrawable();
         ~TriangleSoupDrawable();
-        
+ 
+        void setNode(graphics::NodeID node) const;
+
         graphics::DrawcallObjectPointer getDrawable() const;
 
         void swapUniforms(const TriangleSoupDrawableUniformsPointer& uniforms) { _uniforms = uniforms; }

--- a/src/graphics/drawables/TriangleSoup_vert.hlsl
+++ b/src/graphics/drawables/TriangleSoup_vert.hlsl
@@ -1,16 +1,40 @@
 #define mat43 float4x3
 
-struct View {
+//
+// Transform API
+//
+struct Transform {
     float4 _right_upX;
     float4 _upYZ_backXY;
-    float4 _backZ_eye;
+    float4 _backZ_ori;
 
-    float3 right() { return _right_upX.xyz; }
-    float3 up() { return float3(_right_upX.w, _upYZ_backXY.xy); }
-    float3 back() { return float3(_upYZ_backXY.zw, _backZ_eye.x); }
-    float3 eye() { return _backZ_eye.yzw; }
+    float3 row_x() { return float3(_right_upX.x, _right_upX.w, _upYZ_backXY.z); }
+    float3 row_y() { return float3(_right_upX.y, _upYZ_backXY.x, _upYZ_backXY.w); }
+    float3 row_z() { return float3(_right_upX.z, _upYZ_backXY.y, _backZ_ori.x); }
+
+    float3 col_x() { return _right_upX.xyz; }
+    float3 col_y() { return float3(_right_upX.w, _upYZ_backXY.xy); }
+    float3 col_z() { return float3(_upYZ_backXY.zw, _backZ_ori.x); }
+    float3 col_w() { return _backZ_ori.yzw; }
 };
 
+float3 rotateFrom(const Transform mat, const float3 d) {
+    return float3(dot(mat.row_x(), d), dot(mat.row_y(), d), dot(mat.row_z(), d));
+}
+float3 rotateTo(const Transform mat, const float3 d) {
+    return float3(dot(mat.col_x(), d), dot(mat.col_y(), d), dot(mat.col_z(), d));
+}
+
+float3 transformTo(const Transform mat, const float3 p) {
+    return rotateTo(mat, p - mat.col_w());
+}
+float3 transformFrom(const Transform mat, const float3 p) {
+    return rotateFrom(mat, p) + mat.col_w();
+}
+
+//
+// Projection API
+// 
 struct Projection {
     float4 _aspectRatio_sensorHeight_focal_far;
     float4 _ortho_enabled_height_near_far;
@@ -54,65 +78,55 @@ float4 orthoClipFromEyeSpace(float aspectRatio, float sensorHeight, float pnear,
 float4 clipFromEyeSpace(Projection proj, float3 eyePos) {
     if (proj.isOrtho()) {
         return orthoClipFromEyeSpace(proj.aspectRatio(), proj.orthoHeight(), proj.orthoNear(), proj.orthoFar(), eyePos);
-    } else {
+    }
+    else {
         return clipFromEyeSpace(proj.aspectRatio(), proj.sensorHeight(), proj.focal(), proj.persFar(), eyePos);
     }
 }
 
+// Camera buffer
 cbuffer UniformBlock0 : register(b0) {
     //float4x3 _view;
-    View _view;
+    Transform _view;
     Projection _projection;
     float4 _viewport;
 };
 
 
-float3 eyeFromWorldSpace(float3 right, float3 up, float3 back, float3 eye, float3 worldPos) {
-    // TranslationInv
-    float3 eyeCenteredPos = worldPos - eye;
-    return eyeCenteredPos;
-    // RotationInv
-    return float3(dot(right, eyeCenteredPos), dot(up, eyeCenteredPos), dot(back, eyeCenteredPos));
+float3 eyeFromWorldSpace(Transform view, float3 worldPos) {
+    return transformTo(view, worldPos);
 }
 
-float3 eyeFromWorldSpace(View view, float3 worldPos) {
-    // TranslationInv
-    float3 eyeCenteredPos = worldPos - view.eye();
-    //  return eyeCenteredPos;
-      // RotationInv
-    return float3(dot(view.right(), eyeCenteredPos), dot(view.up(), eyeCenteredPos), dot(view.back(), eyeCenteredPos));
+float3 worldFromObjectSpace(Transform model, float3 objPos) {
+    return transformFrom(model, objPos);
 }
 
-struct Transform {
-    float4 _right_upX;
-    float4 _upYZ_backXY;
-    float4 _backZ_ori;
+float3 objectFromWorldSpaceDir(Transform model, float3 worldDir) {
+    return rotateTo(model, worldDir);
+}
 
-    float3 right() { return _right_upX.xyz; }
-    float3 up() { return float3(_right_upX.w, _upYZ_backXY.xy); }
-    float3 back() { return float3(_upYZ_backXY.zw, _backZ_ori.x); }
+//
+// Transform Tree
+//
+StructuredBuffer<Transform>  tree_transforms : register(t0);
 
-    float3 invX() { return float3(_right_upX.x, _right_upX.w, _upYZ_backXY.z); }
-    float3 invY() { return float3(_right_upX.y, _upYZ_backXY.x, _upYZ_backXY.w); }
-    float3 invZ() { return float3(_right_upX.z, _upYZ_backXY.y, _backZ_ori.x); }
+Transform node_getTransform(int nodeID) {
+    return tree_transforms[2 * nodeID];
+}
+Transform node_getWorldTransform(int nodeID) {
+    return tree_transforms[2 * nodeID + 1];
+}
 
-    float3 ori() { return _backZ_ori.yzw; }
-};
-
+//
+// Instance
+//
 cbuffer UniformBlock1 : register(b1) {
-    Transform _model;
+    int4 _instance;
     int _numVertices;
     int _numIndices;
     int spareA;
     float _triangleScale;
 }
-
-float3 worldFromObjectSpace(Transform model, float3 objPos) {
-    float3 rotatedPos = float3(dot(model.invX(), objPos), dot(model.invY(), objPos), dot(model.invZ(), objPos));
-    // TranslationInv
-    return  rotatedPos + model.ori();
-}
-
 
 struct PointPosColor {
     float x;
@@ -121,8 +135,8 @@ struct PointPosColor {
     uint  color;
 };
 
-StructuredBuffer<PointPosColor>  VerticesIn : register(t0);
-Buffer<uint>  IndicesIn : register(t1);
+StructuredBuffer<PointPosColor>  VerticesIn : register(t1);
+Buffer<uint>  IndicesIn : register(t2);
 
 struct VertexShaderOutput
 {
@@ -158,6 +172,9 @@ VertexShaderOutput main(uint vidx : SV_VertexID) {
     // Transform
     float3 position = faceVerts[tvidx].xyz;
     position += _triangleScale * (barycenter - position);
+
+    Transform _model = node_getWorldTransform(_instance.x);
+
 
     position = worldFromObjectSpace(_model, position);
     float3 eyePosition = eyeFromWorldSpace(_view, position);

--- a/src/graphics/gpu/gpu.h
+++ b/src/graphics/gpu/gpu.h
@@ -85,6 +85,7 @@ namespace graphics {
 
     class Device;
     using DevicePointer = std::shared_ptr<Device>;
+    using DeviceWeakPtr = std::weak_ptr<Device>;
     struct DeviceInit;
 
     class Batch;

--- a/src/graphics/render/Camera.h
+++ b/src/graphics/render/Camera.h
@@ -72,7 +72,7 @@ namespace graphics {
 
         
         static core::vec3 worldFromEyeSpaceDir(const core::vec3& right, const core::vec3& up, const core::vec3& eyeDir) {
-            return eyeDir * eyeDir.x + up * eyeDir.y + cross(right, up) * eyeDir.z;
+            return core::vec3(dot(right, eyeDir), dot(up,  eyeDir), dot(cross(right, up), eyeDir));
         }
         static core::vec3 worldFromEyeSpace(const core::vec3& eye, const core::vec3& right, const core::vec3& up, const core::vec3& eyePos) {
             return worldFromEyeSpaceDir(right, up, eyePos) + eye;

--- a/src/graphics/render/Drawable.cpp
+++ b/src/graphics/render/Drawable.cpp
@@ -25,17 +25,68 @@
 // SOFTWARE.
 //
 #include "Drawable.h"
+#include "gpu/Resource.h"
+#include "gpu/Device.h"
 
 using namespace graphics;
 
 
-void DrawcallObject::draw(
-    const NodeID node,
-    const CameraPointer& camera,
-    const SwapchainPointer& swapchain,
-    const DevicePointer& device,
-    const BatchPointer& batch) {
-    if (_drawCallback) {
-        _drawCallback(node, camera, swapchain, device, batch);
+Drawable Drawable::null;
+
+DrawableID DrawableStore::newID() {
+    return _indexTable.allocate();
+}
+
+Drawable DrawableStore::allocate(Drawable drawable) {
+
+    DrawableID new_id = drawable.id();
+    bool allocated = new_id == (_indexTable.getNumAllocatedElements() - 1);
+
+    auto bound = drawable.getBound();
+
+    if (allocated) {
+        _drawables.push_back(drawable);
+        _bounds.push_back({ bound });
+    }
+    else {
+        _drawables[new_id] = (drawable);
+        _bounds[new_id] = { bound };
+    }
+
+    if (new_id < _num_buffers_elements) {
+        reinterpret_cast<GPUDrawableBound*>(_drawables_buffer->_cpuMappedAddress)[new_id]._local_box = (bound);
+    }
+
+    return drawable;
+}
+
+void DrawableStore::free(DrawableID index) {
+    _indexTable.free(index);
+
+    _drawables[index] = Drawable::null;
+    _bounds[index] = { };
+
+    if (index < _num_buffers_elements) {
+        reinterpret_cast<GPUDrawableBound*>(_drawables_buffer->_cpuMappedAddress)[index]._local_box = core::aabox3();
+    }
+}
+
+
+void DrawableStore::resizeBuffers(const DevicePointer& device, uint32_t numElements) {
+
+    if (_num_buffers_elements < numElements) {
+        auto capacity = (numElements);
+
+        graphics::BufferInit drawables_buffer_init{};
+        drawables_buffer_init.usage = graphics::ResourceUsage::RESOURCE_BUFFER;
+        drawables_buffer_init.hostVisible = true;
+        drawables_buffer_init.bufferSize = capacity * sizeof(GPUDrawableBound);
+        drawables_buffer_init.firstElement = 0;
+        drawables_buffer_init.numElements = capacity;
+        drawables_buffer_init.structStride = sizeof(GPUDrawableBound);
+
+        _drawables_buffer = device->createBuffer(drawables_buffer_init);
+        
+        _num_buffers_elements = capacity;
     }
 }

--- a/src/graphics/render/Drawable.cpp
+++ b/src/graphics/render/Drawable.cpp
@@ -29,11 +29,13 @@
 using namespace graphics;
 
 
-void DrawcallObject::draw(const CameraPointer& camera,
+void DrawcallObject::draw(
+    const NodeID node,
+    const CameraPointer& camera,
     const SwapchainPointer& swapchain,
     const DevicePointer& device,
     const BatchPointer& batch) {
     if (_drawCallback) {
-        _drawCallback(_transform, camera, swapchain, device, batch);
+        _drawCallback(node, camera, swapchain, device, batch);
     }
 }

--- a/src/graphics/render/Drawable.h
+++ b/src/graphics/render/Drawable.h
@@ -31,7 +31,8 @@
 #include <core/math/LinearAlgebra.h>
 
 #include "Renderer.h"
-#include "Scene.h"
+#include "render/Transform.h"
+
 
 namespace graphics {
 
@@ -44,24 +45,98 @@ namespace graphics {
 
     // Here we define the DrawcallObject as the container of the various pico gpu objects we need to render an item.
     // this will evolve and probably clean up over time and move the genralized concepts in the visualization library
-    class VISUALIZATION_API DrawcallObject {
+
+    template <typename T> core::aabox3 drawable_getBound(const T& x) {
+        return x.getBound();
+    }
+    template <typename T> DrawObjectCallback drawable_getDrawcall(const T& x) {
+        return x.getDrawcall();
+    }
+
+    using DrawableID = core::IndexTable::Index;
+    using DrawableIDs = core::IndexTable::Indices;
+    static const DrawableID INVALID_DRAWABLE_ID = core::IndexTable::INVALID_INDEX;
+
+    class VISUALIZATION_API Drawable {
+        Drawable() { } // invalid
+
+        friend class DrawableStore;
+
+        template <typename T> Drawable(DrawableID id, T x) :
+            _self(std::make_shared<Model<T>>(id, std::move(x))) {
+        }
+
     public:
-#pragma warning(push)
-#pragma warning(disable: 4251)
-        DrawObjectCallback _drawCallback;
-        core::Bounds _bounds;
+        static Drawable null;
 
-#pragma warning(pop)
+        DrawableID id() const { return _self->_id; }
+        core::aabox3 getBound() const { return _self->getBound(); }
+        DrawObjectCallback getDrawcall() const { return _self->getDrawcall(); }
 
-        DrawcallObject() : _drawCallback(nullptr) {}
-        DrawcallObject(DrawObjectCallback callback) : _drawCallback(callback) {}
+    private:
+        struct Concept {
+            Concept(DrawableID index) : _id(index) {}
+            virtual ~Concept() = default;
+            virtual core::aabox3 getBound() const = 0;
+            virtual DrawObjectCallback getDrawcall() const = 0;
 
-        void draw(const NodeID node, const CameraPointer& camera,
-            const SwapchainPointer& swapchain,
-            const DevicePointer& device,
-            const BatchPointer& batch);
+            const DrawableID _id{ INVALID_DRAWABLE_ID };
+        };
+        template <typename T> struct Model final : Concept {
+            Model(DrawableID index, T x) : Concept(index), _data(std::move(x)) {}
+
+            core::aabox3 getBound() const override { return drawable_getBound(_data); }
+            DrawObjectCallback getDrawcall() const override { return drawable_getDrawcall(_data); }
+
+            T _data;
+        };
+
+        std::shared_ptr<const Concept> _self;
+    public:
+        template <typename T> T& as() const {
+            return (const_cast<Model<T>*> (
+                        reinterpret_cast<const Model<T>*>(
+                            _self.get()
+                        )
+                    )->_data); }
+
     };
-    using DrawcallObjectPointer = std::shared_ptr<DrawcallObject>;
+
+    class DrawableStore {
+        DrawableID newID();
+        Drawable allocate(Drawable drawable);
+    public:
+
+        template <typename T>
+        Drawable createDrawable(T x) {
+            return allocate(Drawable(newID(), x));
+        }
+        
+        void free(DrawableID index);
+
+        core::aabox3 getBound(DrawableID index) const { return _bounds[index]._local_box; }
+        DrawObjectCallback getDrawcall(DrawableID index) const { return _drawables[index].getDrawcall(); }
+        Drawable getDrawable(DrawableID index) const { return _drawables[index]; }
+
+        struct VISUALIZATION_API GPUDrawableBound {
+            core::aabox3 _local_box;
+            float  _spareA;
+            float  _spareB;
+        };
+        std::vector<GPUDrawableBound> _bounds;
+
+    protected:
+        core::IndexTable _indexTable;
+        std::vector<Drawable> _drawables;
+
+        uint32_t  _num_buffers_elements{ 0 };
+    public:
+        BufferPointer _drawables_buffer;
+        void resizeBuffers(const DevicePointer& device, uint32_t  numElements);
+
+       
+    };
+
 
 }
 

--- a/src/graphics/render/Drawable.h
+++ b/src/graphics/render/Drawable.h
@@ -31,10 +31,12 @@
 #include <core/math/LinearAlgebra.h>
 
 #include "Renderer.h"
+#include "Scene.h"
 
 namespace graphics {
 
-    using DrawObjectCallback = std::function<void(const core::mat4x3& transform,
+    using DrawObjectCallback = std::function<void(
+        const NodeID node,
         const CameraPointer& camera,
         const SwapchainPointer& swapchain,
         const DevicePointer& device,
@@ -48,14 +50,13 @@ namespace graphics {
 #pragma warning(disable: 4251)
         DrawObjectCallback _drawCallback;
         core::Bounds _bounds;
-        core::mat4x3 _transform;
 
 #pragma warning(pop)
 
         DrawcallObject() : _drawCallback(nullptr) {}
         DrawcallObject(DrawObjectCallback callback) : _drawCallback(callback) {}
 
-        void draw(const CameraPointer& camera,
+        void draw(const NodeID node, const CameraPointer& camera,
             const SwapchainPointer& swapchain,
             const DevicePointer& device,
             const BatchPointer& batch);

--- a/src/graphics/render/Item.cpp
+++ b/src/graphics/render/Item.cpp
@@ -1,0 +1,146 @@
+// Item.cpp
+//
+// Sam Gateau - January 2020
+// 
+// MIT License
+//
+// Copyright (c) 2020 Sam Gateau
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#include "Item.h"
+
+#include "gpu/Resource.h"
+#include "gpu/Device.h"
+#include "Drawable.h"
+#include "Scene.h"
+
+namespace graphics {
+
+    Item Item::null;
+
+    void Item::Concept::setVisible(bool visible) {
+         _store->editInfo(_id)._isVisible = visible;
+    }
+
+    void Item::Concept::setNode(Node node) {
+        auto& info = _store->editInfo(_id);
+        info._nodeID = node.id();
+    }
+    void Item::Concept::setDrawable(Drawable drawable) {
+         _store->editInfo(_id)._drawableID = drawable.id();
+    }
+
+    core::aabox3 Item::Concept::fetchWorldBound() const {
+        const auto& info = _store->getInfo(_id);
+        if ((info._nodeID != INVALID_NODE_ID) && (info._drawableID != INVALID_DRAWABLE_ID)) {
+            return core::aabox_transformFrom(_scene->_nodes._tree._worldTransforms[info._nodeID], _scene->_drawables.getBound(info._drawableID));
+        } else {
+            return core::aabox3();
+        }
+    }
+
+    ItemID ItemStore::newID() {
+        return _indexTable.allocate();
+    }
+
+    Item ItemStore::allocate(const Scene* scene, NodeID node, DrawableID drawable) {
+
+        ItemID new_id = newID();
+        Item item(new Item::Concept(scene, this, new_id));
+
+        bool allocated = new_id == (_indexTable.getNumAllocatedElements() - 1);
+
+        if (allocated) {
+            _items.push_back(item);
+            _itemInfos.push_back({node, drawable, true});
+        }
+        else {
+            _items[new_id] = (item);
+            _itemInfos[new_id] = { node, drawable, true };
+        }
+
+        _touchedElements.push_back(new_id);
+
+        return item;
+    }
+
+    Item ItemStore::createItem(const Scene* scene, NodeID node, DrawableID drawable) {
+        return allocate(scene, node, drawable);
+    }
+
+    void ItemStore::free(ItemID index) {
+        _indexTable.free(index);
+
+        _items[index] = Item::null;
+        _itemInfos[index] = ItemInfo();
+
+        _touchedElements.push_back(index);
+    }
+
+    void ItemStore::freeAll() {
+
+    }
+
+    Item ItemStore::getValidItemAt(ItemID startIndex) const {
+        if (startIndex < _items.size()) {
+            do {
+                const auto* item = _items.data() + startIndex;
+                if (item->isValid()) {
+                    return (*item);
+                }
+                startIndex++;
+            } while (startIndex < _items.size());
+        }
+        return Item::null;
+    }
+
+    void ItemStore::resizeBuffers(const DevicePointer& device, uint32_t numElements) {
+
+        if (_num_buffers_elements < numElements) {
+            auto capacity = (numElements);
+
+            graphics::BufferInit items_buffer_init{};
+            items_buffer_init.usage = graphics::ResourceUsage::RESOURCE_BUFFER;
+            items_buffer_init.hostVisible = true;
+            items_buffer_init.bufferSize = capacity * sizeof(ItemInfo);
+            items_buffer_init.firstElement = 0;
+            items_buffer_init.numElements = capacity;
+            items_buffer_init.structStride = sizeof(ItemInfo);
+
+            _items_buffer = device->createBuffer(items_buffer_init);
+
+            _num_buffers_elements = capacity;
+        }
+    }
+
+    void ItemStore::syncBuffer() {
+        if (_touchedElements.empty()) {
+             return;
+        }
+
+        if (_itemInfos.size() < _num_buffers_elements) {
+            for(auto index : _touchedElements) {
+                reinterpret_cast<ItemInfo*>(_items_buffer->_cpuMappedAddress)[index] = _itemInfos[index];
+            }
+            _touchedElements.clear();
+        }
+    }
+
+}

--- a/src/graphics/render/Item.h
+++ b/src/graphics/render/Item.h
@@ -1,0 +1,153 @@
+// Item.h 
+//
+// Sam Gateau - January 2020
+// 
+// MIT License
+//
+// Copyright (c) 2020 Sam Gateau
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#pragma once
+
+#include <vector>
+#include <unordered_map>
+#include <iostream>
+#include <core/math/LinearAlgebra.h>
+
+#include "render/Transform.h"
+
+#include "render/Drawable.h"
+
+#include "render/Renderer.h"
+
+namespace graphics {
+
+    using ItemID = core::IndexTable::Index;
+    using ItemIDs = core::IndexTable::Indices;
+    static const ItemID INVALID_ITEM_ID = core::IndexTable::INVALID_INDEX;
+
+
+    class ItemStore;
+
+    class VISUALIZATION_API Item {
+    public:
+        static Item null;
+
+        Item(const Item& src) = default;
+        Item& Item::operator= (const Item&) = default;
+
+        bool isValid() const { return (_self.get() != nullptr); }
+        ItemID id() const { return  _self->id(); }
+
+        void setVisible(bool visible) { _self->setVisible(visible); }
+        bool isVisible() const { return _self->isVisible(); }
+
+        void setNode(Node node) { _self->setNode(node); }
+        NodeID getNode() const { return _self->getNode(); }
+
+        void setDrawable(Drawable drawable) { _self->setDrawable(drawable); }
+        DrawableID getDrawable() const { return _self->getDrawable(); }
+
+        core::aabox3 fetchWorldBound() const { return _self->fetchWorldBound(); }
+
+    private:
+        struct Concept {
+            const Scene* _scene{ nullptr };
+            const ItemStore* _store{ nullptr };
+            const ItemID _id{ INVALID_ITEM_ID };
+
+            NodeID _nodeID{ INVALID_NODE_ID };
+            DrawableID _drawableID{ INVALID_DRAWABLE_ID };
+            bool _isVisible{ true };
+    
+            Concept(const Scene* scene, const ItemStore* store, ItemID index) :
+                _scene(scene),
+                _store(store),
+                _id(index) {}
+
+            ItemID id() const { return  _id; }
+
+            void setVisible(bool visible);
+            bool isVisible() const;
+            void setNode(Node node);
+            NodeID getNode() const;
+            void setDrawable(Drawable drawable);
+            DrawableID getDrawable() const;
+
+            core::aabox3 fetchWorldBound() const;
+        };
+
+        std::shared_ptr<Concept> _self;
+
+        Item() { } // invalid
+        friend class ItemStore;
+        Item(Concept* self) : _self(self) { }
+    };
+
+    using Items = std::vector<Item>;
+
+    class ItemStore {
+        ItemID newID();
+        Item allocate(const Scene* scene, NodeID node, DrawableID drawable);
+    public:
+
+        struct ItemInfo {
+            NodeID _nodeID{ INVALID_NODE_ID };
+            DrawableID _drawableID{ INVALID_DRAWABLE_ID };
+            uint32_t _isVisible{ true };
+            uint32_t spareB;
+        };
+
+        Item createItem(const Scene* scene, NodeID node = INVALID_NODE_ID, DrawableID drawable = INVALID_DRAWABLE_ID);
+        void free(ItemID index);
+        void freeAll();
+
+        Item getItem(ItemID index) const { return _items[index]; }
+        Item getValidItemAt(ItemID index) const;
+
+        const Items& getItems() const { return _items; };
+        const ItemInfo& getInfo(ItemID index) const { return _itemInfos[index]; }
+
+    protected:
+        friend class Item;
+        friend class Scene;
+        core::IndexTable _indexTable;
+        Items _items;
+        mutable std::vector<ItemInfo> _itemInfos;
+        
+        ItemInfo& editInfo(ItemID index) const { _touchedElements.push_back(index);  return _itemInfos[index]; }
+
+        uint32_t  _num_buffers_elements{ 0 };
+        mutable std::vector<ItemID> _touchedElements;
+    public:
+        BufferPointer _items_buffer;
+        void resizeBuffers(const DevicePointer& device, uint32_t  numElements);
+        void syncBuffer();
+    };
+
+
+    inline bool Item::Concept::isVisible() const { return _store->getInfo(_id)._isVisible; }
+    inline NodeID Item::Concept::getNode() const { return _store->getInfo(_id)._nodeID; }
+    inline DrawableID Item::Concept::getDrawable() const { return _store->getInfo(_id)._drawableID; }
+
+
+    using IDToIndices = std::unordered_map<ItemID, uint32_t>;
+
+}

--- a/src/graphics/render/Scene.cpp
+++ b/src/graphics/render/Scene.cpp
@@ -26,6 +26,8 @@
 //
 #include "Scene.h"
 
+#include "Drawable.h"
+
 namespace graphics {
 
 Item Item::null;
@@ -101,8 +103,8 @@ const Item& Scene::getValidItemAt(uint32_t startIndex) const {
 }
 
 // Nodes
-NodeID Scene::createNode(const core::mat4x3& rts, NodeID parent) {
-    return _transformTree->createNode(rts, parent);
+Node Scene::createNode(const core::mat4x3& rts, NodeID parent) {
+    return Node(_transformTree, _transformTree->createNode(rts, parent));
 }
 
 void Scene::deleteNode(NodeID nodeId) {
@@ -117,5 +119,13 @@ void Scene::detachNode(NodeID child) {
     _transformTree->detachNode(child);
 }
 
+void Item::Concept::setNode(Node node) const {
+    _nodeID = node.id();
+
+    node.tree()->editBound(node.id(), [&](core::aabox3& box) {
+        box = _getDrawable()->_bounds.toBox();
+        return true;
+        });
+}
 
 }

--- a/src/graphics/render/Scene.cpp
+++ b/src/graphics/render/Scene.cpp
@@ -31,7 +31,7 @@ namespace graphics {
 Item Item::null;
 
 Scene::Scene() {
-
+    _transformTree = std::make_shared<TransformTreeGPU>();
 }
 
 Scene::~Scene() {
@@ -100,6 +100,22 @@ const Item& Scene::getValidItemAt(uint32_t startIndex) const {
     return Item::null;
 }
 
+// Nodes
+NodeID Scene::createNode(const core::mat4x3& rts, NodeID parent) {
+    return _transformTree->createNode(rts, parent);
+}
+
+void Scene::deleteNode(NodeID nodeId) {
+    _transformTree->deleteNode(nodeId);
+}
+
+void Scene::attachNode(NodeID child, NodeID parent) {
+    _transformTree->attachNode(child, parent);
+}
+
+void Scene::detachNode(NodeID child) {
+    _transformTree->detachNode(child);
 }
 
 
+}

--- a/src/graphics/render/Scene.h
+++ b/src/graphics/render/Scene.h
@@ -39,6 +39,21 @@ namespace graphics {
     using NodeID = TransformTree::NodeID;
     const static NodeID INVALID_NODE_ID {TransformTree::INVALID_ID};
 
+    class VISUALIZATION_API Node {
+        Node() { } // invalid
+        friend class Scene;
+        Node(TransformTreeGPUPointer transformTree, NodeID index) : _transformTree(transformTree), _index(index) { }
+
+        TransformTreeGPUPointer _transformTree;
+        NodeID _index;
+    public:
+
+        Node(const Node& node) : _transformTree(node._transformTree), _index(node._index) {}
+
+        TransformTreeGPUPointer tree() const { return _transformTree; }
+        NodeID id() const { return _index; }
+    };
+
     template <typename T> void log(const T& x, std::ostream& out, size_t position) {
         out << std::string(position, ' ') << std::endl;
     }
@@ -79,7 +94,7 @@ namespace graphics {
         bool isVisible() const { return _self->isVisible(); }
         void setVisible(bool visible) { _self->setVisible(visible); }
 
-        void setNode(NodeID nodeID) { _self->setNode(nodeID); }
+        void setNode(Node node) { _self->setNode(node); }
         NodeID getNode() const { return _self->getNode(); }
 
     private:
@@ -91,7 +106,7 @@ namespace graphics {
 
             uint32_t getIndex() const { return _index; }
 
-            void setNode(NodeID node) const { _nodeID = node; }
+            void setNode(Node node) const;
             NodeID getNode() const { return _nodeID; }
 
             bool isVisible() const { return _isVisible; }
@@ -121,6 +136,7 @@ namespace graphics {
     using IDToIndices = std::unordered_map<ItemID, uint32_t>;
 
 
+
     class VISUALIZATION_API Scene {
     public:
         Scene();
@@ -144,7 +160,7 @@ namespace graphics {
 
 
         // Nodes
-        NodeID createNode(const core::mat4x3& rts, NodeID parent);
+        Node createNode(const core::mat4x3& rts, NodeID parent);
         void deleteNode(NodeID nodeId);
 
         void attachNode(NodeID child, NodeID parent);

--- a/src/graphics/render/Scene.h
+++ b/src/graphics/render/Scene.h
@@ -33,149 +33,60 @@
 
 #include "Renderer.h"
 #include "render/Transform.h"
+#include "render/Drawable.h"
+#include "render/Item.h"
 
 namespace graphics {
-  
-    using NodeID = TransformTree::NodeID;
-    const static NodeID INVALID_NODE_ID {TransformTree::INVALID_ID};
-
-    class VISUALIZATION_API Node {
-        Node() { } // invalid
-        friend class Scene;
-        Node(TransformTreeGPUPointer transformTree, NodeID index) : _transformTree(transformTree), _index(index) { }
-
-        TransformTreeGPUPointer _transformTree;
-        NodeID _index;
-    public:
-
-        Node(const Node& node) : _transformTree(node._transformTree), _index(node._index) {}
-
-        TransformTreeGPUPointer tree() const { return _transformTree; }
-        NodeID id() const { return _index; }
-    };
-
-    template <typename T> void log(const T& x, std::ostream& out, size_t position) {
-        out << std::string(position, ' ') << std::endl;
-    }
-
-    template <typename T> DrawcallObjectPointer item_getDrawable(const T& x) {
-        return x->getDrawable();
-    }
-
-    using ItemID = uint32_t;
-
-    class VISUALIZATION_API Item {
-        Item() { } // invalid
-        friend class Scene;
-    public:
-        static const ItemID INVALID_ITEM_ID{ 0xFFFFFFFF };
-        static Item null;
-
-        template <typename T> Item(uint32_t index, T x):
-            _self(std::make_shared<Model<T>>(index, std::move(x))) {
-        }
-
-        friend void log(const Item& x, std::ostream& out, size_t position) {
-            x._self->_log(out, position);
-        }
-
-        DrawcallObjectPointer getDrawable() const { 
-            return _self->_getDrawable();
-        }
-            
-        friend DrawcallObjectPointer getDrawable(const Item& x) {
-            return x._self->_getDrawable();
-        }
-
-        bool isValid() const { return (_self != nullptr); }
-
-        uint32_t getIndex() const { return  _self->getIndex(); }
-
-        bool isVisible() const { return _self->isVisible(); }
-        void setVisible(bool visible) { _self->setVisible(visible); }
-
-        void setNode(Node node) { _self->setNode(node); }
-        NodeID getNode() const { return _self->getNode(); }
-
-    private:
-        struct Concept{
-            Concept(uint32_t index) : _index(index) {}
-            virtual ~Concept() = default;
-            virtual void _log(std::ostream& out, size_t position) const = 0;
-            virtual DrawcallObjectPointer _getDrawable() const = 0;
-
-            uint32_t getIndex() const { return _index; }
-
-            void setNode(Node node) const;
-            NodeID getNode() const { return _nodeID; }
-
-            bool isVisible() const { return _isVisible; }
-            void setVisible(bool visible) const { _isVisible = visible; }
-
-            const uint32_t _index;
-            mutable NodeID _nodeID{ INVALID_NODE_ID };
-            mutable bool _isVisible { true };
-        };
-        template <typename T> struct Model final : Concept {
-             Model(uint32_t index, T x) : Concept(index), _data(std::move(x)) {}
-
-             void _log(std::ostream& out, size_t position) const override {
-                log(_data, out, position);
-             }
-
-             DrawcallObjectPointer _getDrawable() const override {
-                 return item_getDrawable(_data);
-             }
-            
-             T _data;
-        };
-
-        std::shared_ptr<const Concept> _self;
-    };
-    using Items = std::vector<Item>;
-    using IDToIndices = std::unordered_map<ItemID, uint32_t>;
-
-
+    using UserID  = uint32_t;  
 
     class VISUALIZATION_API Scene {
     public:
         Scene();
         ~Scene();
 
-
-        template <typename T>
-        Item createItem(T& x, ItemID userID = Item::INVALID_ITEM_ID) {
-            return _createItem(Item((uint32_t)_items.size(), x), userID);
-        }
+        // Items
+        ItemStore _items;
+        Item getItem(ItemID id) const;
+        
+        Item createItem(UserID userID = INVALID_ITEM_ID);
 
         void deleteAllItems();  // delete all user objects
         void deleteAll();
-        Item deleteItem(ItemID id);
+        void deleteItem(UserID id);
 
-        Item getItemFromID(ItemID id) const;
-        const Items& getItems() const { return _items; } // THe all items, beware this contains  INVALID items
-        const Item& getValidItemAt(uint32_t startIndex) const;
-
-        const core::Bounds& getBounds() const { return _bounds; }
-
+        Item getItemFromID(UserID id) const;
+        Item getValidItemAt(uint32_t startIndex) const;
+        const Items& getItems() const; // THe all items, beware this contains  INVALID items
 
         // Nodes
+        NodeStore _nodes;
+        Node getNode(NodeID nodeId) const;
+
         Node createNode(const core::mat4x3& rts, NodeID parent);
         void deleteNode(NodeID nodeId);
 
         void attachNode(NodeID child, NodeID parent);
         void detachNode(NodeID child);
 
-        TransformTreeGPUPointer _transformTree;
+
+        // Drawables
+        DrawableStore _drawables;
+        Drawable getDrawable(DrawableID drawableId) const;
+
+        template <typename T>
+        Drawable createDrawable(T& x) {
+            return _drawables.createDrawable(x);
+        }
+
+        // Bound;
+        void updateBounds();
+        const core::Bounds& getBounds() const { return _bounds; }
 
     protected:
 
-        Items _items;
         IDToIndices _idToIndices;
 
         core::Bounds _bounds;
-
-        Item _createItem(Item& newItem, ItemID userID);
     };
 
 }

--- a/src/graphics/render/Transform.cpp
+++ b/src/graphics/render/Transform.cpp
@@ -25,4 +25,256 @@
 // SOFTWARE.
 //
 #include "Transform.h"
+#include <core/log.h>
+#include "gpu/Resource.h"
+#include "gpu/Device.h"
 
+using namespace core;
+using namespace graphics;
+
+
+TransformTree::NodeID TransformTree::allocate(const core::mat4x3& rts, const core::aabox3& box, NodeID parent) {
+
+    NodeID new_node_id = _indexTable.allocate();
+    bool allocated = new_node_id == (_indexTable.getNumAllocatedElements() - 1);
+
+    if (allocated) {
+        _treeNodes.push_back(Node());
+        _nodeTransforms.push_back(rts);
+        _nodeBoxes.push_back(box);
+        _worldTransforms.push_back(rts);
+        _worlSpheres.push_back(box.toSphere());
+    } else {
+        _treeNodes[new_node_id] = Node();
+        _nodeTransforms[new_node_id] = rts;
+        _nodeBoxes[new_node_id] = box;
+        _worldTransforms[new_node_id] = rts;
+        _worlSpheres[new_node_id] = box.toSphere();
+    }
+
+    attachNode(new_node_id, parent);
+
+    return new_node_id;
+}
+
+void TransformTree::free(NodeID nodeId) {
+    _indexTable.free(nodeId);
+
+    _treeNodes[nodeId] = Node();
+    _nodeTransforms[nodeId] = core::mat4x3();
+    _nodeBoxes[nodeId] = core::aabox3();
+    _worldTransforms[nodeId] = core::mat4x3();
+    _worlSpheres[nodeId] = core::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+}
+
+void TransformTree::attachNode(NodeID node_id, NodeID parent_id) {
+    picoAssert(_indexTable.isValid(node_id));
+
+    // Make sure the node is detached first
+    detachNode(node_id);
+
+    auto& the_node = _treeNodes[node_id];
+    the_node.parent = parent_id;
+
+    if (parent_id != INVALID_ID) {
+        auto& parent_node = _treeNodes[parent_id];
+
+        the_node.parent = parent_id;
+        the_node.sybling = parent_node.children_head;
+
+        parent_node.children_head = node_id;
+        parent_node.num_children++;
+
+        _touchedBounds.push_back(parent_id);
+    }
+
+    _touchedTransforms.push_back(node_id);
+
+
+    // invalid:
+    // node world transform and world sphere
+    // children world transform and world sphere
+}
+
+void TransformTree::detachNode(NodeID node_id) {
+    auto& the_node = _treeNodes[node_id];
+    if (the_node.parent == INVALID_ID) {
+        return;
+    }
+    auto& parent_node = _treeNodes[the_node.parent];
+    _touchedBounds.push_back(the_node.parent);
+
+    auto left_sybling_id = parent_node.children_head;
+    if (left_sybling_id == node_id) {
+        parent_node.children_head = the_node.sybling;
+        parent_node.num_children--;
+    } else {
+
+        for (int i = 0; i < parent_node.num_children; i++) {
+            auto& sybling_node = _treeNodes[left_sybling_id];
+            if (sybling_node.sybling == node_id) {
+                sybling_node.sybling = the_node.sybling;
+                parent_node.num_children--;
+                break;
+            }
+
+            left_sybling_id = sybling_node.sybling;
+            picoAssert(left_sybling_id != INVALID_ID);
+        }
+
+        // Should never happen
+        picoAssert(left_sybling_id != INVALID_ID);
+    }
+
+
+    the_node.parent = INVALID_ID;
+    the_node.sybling = INVALID_ID;
+}
+
+void TransformTree::editTransform(NodeID nodeId, std::function<bool(core::mat4x3& rts)> editor) {
+    if (editor(_nodeTransforms[nodeId])) {
+        _touchedTransforms.push_back(nodeId);
+    }
+}
+
+TransformTree::NodeIDs TransformTree::updateTransforms() {
+    NodeIDs touched;
+    for (auto node_id : _touchedTransforms) {
+        const auto& node = _treeNodes[node_id];
+        if (node.parent == INVALID_ID) {
+            _worldTransforms[node_id] = _nodeTransforms[node_id];
+        } else {
+            _worldTransforms[node_id] = core::mul(_worldTransforms[node.parent], _nodeTransforms[node_id]);
+        }
+        touched.push_back(node_id);
+        updateChildrenTransforms(node_id, touched);
+    }
+    _touchedTransforms.clear();
+
+    return touched;
+}
+
+
+void TransformTree::updateChildrenTransforms(NodeID parentId, NodeIDs& touched) {
+
+    const auto& node = _treeNodes[parentId];
+    if (node.num_children == 0) {
+        return;
+    }
+    const auto& parent_world_transform = _worldTransforms[parentId];
+
+    NodeIDs children;
+    children.reserve(node.num_children);
+
+    NodeID child_id = node.children_head;
+    for (int i = 0; i < node.num_children; ++i) {
+        _worldTransforms[child_id] = core::mul(parent_world_transform, _nodeTransforms[child_id]);
+        touched.push_back(child_id);
+
+        const auto& child = _treeNodes[child_id];
+        if (child.num_children > 0) {
+            children.push_back(child_id);
+        }
+        child_id = child.sybling;
+    }
+
+    for (auto& id : children) {
+        updateChildrenTransforms(id, touched);
+    }
+}
+
+
+TransformTreeGPU::TransformTreeGPU() {
+
+
+}
+
+TransformTreeGPU::~TransformTreeGPU() {
+
+}
+
+
+void TransformTreeGPU::resizeBuffers(const DevicePointer& device, uint32_t  numElements) {
+
+    if (_num_buffers_elements < numElements) {
+        auto capacity = (numElements);
+
+        graphics::BufferInit nodes_buffer_init{};
+        nodes_buffer_init.usage = graphics::ResourceUsage::RESOURCE_BUFFER;
+        nodes_buffer_init.hostVisible = true;
+        nodes_buffer_init.bufferSize = capacity * sizeof(vec4);
+        nodes_buffer_init.firstElement = 0;
+        nodes_buffer_init.numElements = capacity;
+        nodes_buffer_init.structStride = sizeof(vec4);
+
+        _nodes_buffer = device->createBuffer(nodes_buffer_init);
+
+
+        graphics::BufferInit transforms_buffer_init{};
+        transforms_buffer_init.usage = graphics::ResourceUsage::RESOURCE_BUFFER;
+        transforms_buffer_init.hostVisible = true;
+        transforms_buffer_init.bufferSize = 2 * capacity * sizeof(mat4x3);
+        transforms_buffer_init.firstElement = 0;
+        transforms_buffer_init.numElements = 2 * capacity;
+        transforms_buffer_init.structStride = sizeof(mat4x3);
+
+        _transforms_buffer = device->createBuffer(transforms_buffer_init);
+
+
+        graphics::BufferInit bounds_buffer_init{};
+        bounds_buffer_init.usage = graphics::ResourceUsage::RESOURCE_BUFFER;
+        bounds_buffer_init.hostVisible = true;
+        bounds_buffer_init.bufferSize = capacity * sizeof(vec4);
+        bounds_buffer_init.firstElement = 0;
+        bounds_buffer_init.numElements = capacity;
+        bounds_buffer_init.structStride = sizeof(vec4);
+
+        _bounds_buffer = device->createBuffer(bounds_buffer_init);
+
+    }
+}
+
+
+TransformTree::NodeID TransformTreeGPU::createNode(const core::mat4x3& rts, NodeID parent) {
+    auto nodeId = _tree.allocate(rts, core::aabox3(), parent);
+    
+    reinterpret_cast<TransformTree::Node*>(_nodes_buffer->_cpuMappedAddress)[nodeId] = _tree._treeNodes[nodeId];
+    reinterpret_cast<core::mat4x3*>(_transforms_buffer->_cpuMappedAddress)[2 * nodeId] = _tree._nodeTransforms[nodeId];
+   // reinterpret_cast<core::vec4*>(_bounds_buffer->_cpuMappedAddress)[nodeId] = _tree._nodeBoxes[nodeId];
+
+    return nodeId;
+}
+
+void TransformTreeGPU::deleteNode(NodeID nodeId) {
+    _tree.free(nodeId);
+}
+
+void TransformTreeGPU::attachNode(NodeID child, NodeID parent) {
+    _tree.attachNode(child, parent);
+}
+
+void TransformTreeGPU::detachNode(NodeID child) {
+    _tree.detachNode(child);
+}
+
+void TransformTreeGPU::editTransform(NodeID nodeId, std::function<bool(core::mat4x3& rts)> editor) {
+    auto gpu_transforms = reinterpret_cast<core::mat4x3*>(_transforms_buffer->_cpuMappedAddress);
+
+    _tree.editTransform(nodeId, [gpu_transforms, editor, nodeId] (core::mat4x3& rts) {
+        editor(rts);
+        gpu_transforms[2 * nodeId] = rts;
+        return true;
+    });
+
+}
+
+void TransformTreeGPU::updateTransforms() {    
+    auto touched_ids = _tree.updateTransforms();
+    if (!touched_ids.empty()) {
+        auto gpu_transforms = reinterpret_cast<core::mat4x3*>(_transforms_buffer->_cpuMappedAddress);
+    
+        for (const auto& id : touched_ids) {
+            gpu_transforms[2 * id + 1] = _tree._worldTransforms[id];
+        }
+    }
+}

--- a/src/graphics/render/Transform.h
+++ b/src/graphics/render/Transform.h
@@ -34,20 +34,6 @@
 
 #include <gpu/gpu.h>
 
-namespace core {
-    class aabox3 {
-        public:
-        vec3 center{ 0.0f };
-        vec3 half_size{ 1.0f };
-
-        aabox3() {};
-        aabox3(const vec3& center) : center(center) {};
-        aabox3(const vec3& center, const vec3& half_size) : center(center), half_size(half_size) {};
-        
-        vec4 toSphere() const { return vec4(center, length(half_size)); }
-    };
-}
-
 namespace graphics {
     class Transform {
     public:
@@ -87,8 +73,10 @@ namespace graphics {
         void updateChildrenTransforms(NodeID parent, NodeIDs& touched);
 
    //     void editBox(NodeID nodeId, std::function<bool (core::aabox3& box)> editor);
-        
-        
+
+        void editBound(NodeID nodeId, std::function<bool(core::aabox3& bound)> editor);
+        NodeIDs updateBounds();
+
         void attachNode(NodeID child, NodeID parent);
         void detachNode(NodeID child);
 
@@ -106,6 +94,12 @@ namespace graphics {
         std::vector<NodeID> _touchedBounds;
     };
 
+    struct GPUNodeBound {
+        core::aabox3 _local_box;
+        float  _spareA;
+        float  _spareB;
+        core::vec4 _world_sphere;
+    };
 
     class TransformTreeGPU {
         public:
@@ -133,6 +127,10 @@ namespace graphics {
         void editTransform(NodeID nodeId, std::function<bool(core::mat4x3& rts)> editor);
 
         void updateTransforms();
+
+        void editBound(NodeID nodeId, std::function<bool(core::aabox3& bound)> editor);
+
+        void updateBounds();
 
    };
 

--- a/src/graphics/render/Viewport.cpp
+++ b/src/graphics/render/Viewport.cpp
@@ -115,14 +115,14 @@ void Viewport::renderScene(const graphics::CameraPointer& camera, const graphics
     for (int i = 1; i < _scene->getItems().size(); i++) {
         auto& item = _scene->getItems()[i];
         if (item.isValid() && item.isVisible()) {
-            getDrawable(item)->draw(item.getNode(), camera, swapchain, device, batch);
+            _scene->_drawables.getDrawcall(item.getDrawable())(item.getNode(), camera, swapchain, device, batch);
         }
     }
 
     if (_scene->getItems().size() > 0) {
         auto item0 = _scene->getItems()[0];
         if (item0.isValid() && item0.isVisible()) {
-            getDrawable(item0)->draw(item0.getNode(), camera, swapchain, device, batch);
+            _scene->_drawables.getDrawcall(item0.getDrawable())(item0.getNode(), camera, swapchain, device, batch);
         }
     }
 }

--- a/src/graphics/render/Viewport.cpp
+++ b/src/graphics/render/Viewport.cpp
@@ -115,14 +115,14 @@ void Viewport::renderScene(const graphics::CameraPointer& camera, const graphics
     for (int i = 1; i < _scene->getItems().size(); i++) {
         auto& item = _scene->getItems()[i];
         if (item.isValid() && item.isVisible()) {
-            getDrawable(_scene->getItems()[i])->draw(camera, swapchain, device, batch);
+            getDrawable(item)->draw(item.getNode(), camera, swapchain, device, batch);
         }
     }
 
     if (_scene->getItems().size() > 0) {
         auto item0 = _scene->getItems()[0];
         if (item0.isValid() && item0.isVisible()) {
-            getDrawable(_scene->getItems()[0])->draw(camera, swapchain, device, batch);
+            getDrawable(item0)->draw(item0.getNode(), camera, swapchain, device, batch);
         }
     }
 }

--- a/src/graphics/render/render.h
+++ b/src/graphics/render/render.h
@@ -45,13 +45,5 @@ namespace graphics {
 
     class Mesh;
     using MeshPointer = std::shared_ptr<Mesh>;
-
-    class PointCloud;
-    using PointCloudPointer = std::shared_ptr<PointCloud>;
-
-    class DrawcallObject;
-    using DrawcallObjectPointer = std::shared_ptr<DrawcallObject>;
-
-
 }
 

--- a/src/uix/CameraController.h
+++ b/src/uix/CameraController.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <chrono>
+#include <core/math/LinearAlgebra.h>
 #include <graphics/render/render.h>
 
 namespace uix {
@@ -54,17 +55,21 @@ namespace uix {
 
             float _zoomIn{ 0 };
             float _zoomOut{ 0 };
+
+            float _boomLength{ 1.0f };
         };
 
         ControlData _controlData;
 
-        void updateCameraFromController(ControlData& control, std::chrono::milliseconds& duration);
+        void updateCameraFromController(ControlData& control, std::chrono::microseconds& duration);
 
-        void update(std::chrono::milliseconds& duration);
+        void update(std::chrono::microseconds& duration);
 
         bool onKeyboard(const KeyboardEvent& e);
         bool onMouse(const MouseEvent& e);
         bool onResize(const ResizeEvent& e);
 
-        };
+        float zoomTo(const core::vec4& sphere);
+
+    };
 }

--- a/test/pico_04/pico_four.cpp
+++ b/test/pico_04/pico_four.cpp
@@ -52,6 +52,9 @@
 #include <document/TriangleSoup.h>
 #include <graphics/drawables/TriangleSoupDrawable.h>
 
+#include <graphics/drawables/GizmoDrawable.h>
+
+
 #include <uix/Window.h>
 
 #include <vector>
@@ -131,6 +134,16 @@ int main(int argc, char *argv[])
     graphics::TriangleSoupDrawablePointer triangleSoupDrawable(triangleSoupDrawableFactory->createTriangleSoupDrawable(gpuDevice, triangleSoup));
     triangleSoupDrawableFactory->allocateDrawcallObject(gpuDevice, camera, triangleSoupDrawable);
     auto tsitem = scene->createItem(triangleSoupDrawable);
+
+    // A gizmo drawable factory
+    auto gizmoDrawableFactory = std::make_shared<graphics::GizmoDrawableFactory>();
+    gizmoDrawableFactory->allocateGPUShared(gpuDevice);
+
+    // a drawable from the trianglesoup
+    graphics::GizmoDrawablePointer gizmoDrawable(gizmoDrawableFactory->createGizmoDrawable(gpuDevice));
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, camera, gizmoDrawable);
+    auto gitem = scene->createItem(gizmoDrawable);
+
 
     // Content creation
     float doAnimate = 1.0f;

--- a/test/pico_04/pico_four.cpp
+++ b/test/pico_04/pico_four.cpp
@@ -56,6 +56,7 @@
 
 
 #include <uix/Window.h>
+#include <uix/CameraController.h>
 
 #include <vector>
 
@@ -66,6 +67,7 @@
 // render::Camera
 // render::Viewport
 // drawable::PointcloudDrawable
+// uix::CameraController
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------
@@ -106,7 +108,9 @@ int main(int argc, char *argv[])
 
     // Second a Scene
     auto scene = std::make_shared<graphics::Scene>();
-    scene->_transformTree->resizeBuffers(gpuDevice, 100);
+    scene->_items.resizeBuffers(gpuDevice, 100);
+    scene->_nodes.resizeBuffers(gpuDevice, 100);
+    scene->_drawables.resizeBuffers(gpuDevice, 100);
   
     // A Camera to look at the scene
     auto camera = std::make_shared<graphics::Camera>();
@@ -123,31 +127,28 @@ int main(int argc, char *argv[])
     pointCloudDrawableFactory->allocateGPUShared(gpuDevice);
 
     // a drawable from the pointcloud
-    graphics::PointCloudDrawablePointer pointCloudDrawable(pointCloudDrawableFactory->createPointCloudDrawable(gpuDevice, pointCloud));
-    pointCloudDrawableFactory->allocateDrawcallObject(gpuDevice, scene->_transformTree, camera, pointCloudDrawable);
-    auto pcitem = scene->createItem(pointCloudDrawable);
+    graphics::PointCloudDrawable* pointCloudDrawable(pointCloudDrawableFactory->createPointCloudDrawable(gpuDevice, pointCloud));
+    pointCloudDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, *pointCloudDrawable);
+    auto pcdrawable = scene->createDrawable(*pointCloudDrawable);
 
     // A triangel soup drawable factory
     auto triangleSoupDrawableFactory = std::make_shared<graphics::TriangleSoupDrawableFactory>();
     triangleSoupDrawableFactory->allocateGPUShared(gpuDevice);
 
     // a drawable from the trianglesoup
-    graphics::TriangleSoupDrawablePointer triangleSoupDrawable(triangleSoupDrawableFactory->createTriangleSoupDrawable(gpuDevice, triangleSoup));
-    triangleSoupDrawableFactory->allocateDrawcallObject(gpuDevice, scene->_transformTree, camera, triangleSoupDrawable);
-    auto tsitem = scene->createItem(triangleSoupDrawable);
+    graphics::TriangleSoupDrawable* triangleSoupDrawable(triangleSoupDrawableFactory->createTriangleSoupDrawable(gpuDevice, triangleSoup));
+    triangleSoupDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, *triangleSoupDrawable);
+    auto tsdrawable = scene->createDrawable(*triangleSoupDrawable);
 
     // A gizmo drawable factory
     auto gizmoDrawableFactory = std::make_shared<graphics::GizmoDrawableFactory>();
     gizmoDrawableFactory->allocateGPUShared(gpuDevice);
 
-    // a gizmo drawable to draw the transforms
-    graphics::GizmoDrawablePointer gizmoDrawable(gizmoDrawableFactory->createGizmoDrawable(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene->_transformTree, camera, gizmoDrawable);
-    auto gitem = scene->createItem(gizmoDrawable);
 
+    // Some nodes to layout the scene and animate objects
     auto node0 = scene->createNode(core::mat4x3(), -1);
-   
-     auto rnode = scene->createNode(core::translation(core::vec3(4.0f, 0.0f, 0.0f)), node0.id());
+ 
+    auto rnode = scene->createNode(core::translation(core::vec3(4.0f, 0.0f, 0.0f)), node0.id());
 
     auto bnode = scene->createNode(core::translation(core::vec3(8.0f, 0.0f, 0.0f)), rnode.id());
 
@@ -158,37 +159,51 @@ int main(int argc, char *argv[])
     auto enode = scene->createNode(core::translation(core::vec3(0.0f, 1.0f, 4.0f)), rnode.id());
 
 
-    gizmoDrawable->nodes.push_back(node0.id());
-    gizmoDrawable->nodes.push_back(rnode.id());
-    gizmoDrawable->nodes.push_back(bnode.id());
-    gizmoDrawable->nodes.push_back(cnode.id());
-    gizmoDrawable->nodes.push_back(dnode.id());
-    gizmoDrawable->nodes.push_back(enode.id());
+    // a gizmo drawable to draw the transforms
+    auto gzdrawable = scene->createDrawable(*gizmoDrawableFactory->createNodeGizmo(gpuDevice));
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable.as<graphics::NodeGizmo>());
+    gzdrawable.as<graphics::NodeGizmo>().nodes.resize(5);
 
-    auto pcitem2 = scene->createItem(pointCloudDrawable);
-    auto tsitem2 = scene->createItem(triangleSoupDrawable);
+    auto gzdrawable_item = scene->createDrawable(*gizmoDrawableFactory->createItemGizmo(gpuDevice));
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_item.as<graphics::ItemGizmo>());
+    gzdrawable_item.as<graphics::ItemGizmo>().items.resize(5);
 
-    tsitem.setNode(enode);
+    // Some items unique instaces of the drawable and the specified nodes
+    auto pcitem = scene->createItem();
+    pcitem.setDrawable(pcdrawable);
     pcitem.setNode(node0);
-// pcitem2.setNode(dnode);
+
+    auto tsitem = scene->createItem();
+    tsitem.setDrawable(tsdrawable);
+    tsitem.setNode(enode);
+
+    auto pcitem2 = scene->createItem();
+    pcitem2.setDrawable(pcdrawable);
+    pcitem2.setNode(cnode);
+
+    auto tsitem2 = scene->createItem();
+    tsitem2.setDrawable(tsdrawable);
     tsitem2.setNode(dnode);
 
-    // Content creation
-    float doAnimate = 1.0f;
 
-    core::vec4 sceneSphere(0.0f, 0.0f, 0.0f, 10.0f);
-    {
-        auto item = scene->getValidItemAt(0);
-        if (item.isValid()) {
-            // Configure the Camera to look at the scene
-            auto bounds = item.getDrawable()->_bounds;
-            auto cloudCenter = bounds.midPos();
-            auto cloudHalfSize = (bounds.maxPos() - bounds.minPos());
-            auto cloudHalfDiag = sqrt(core::dot(cloudHalfSize, cloudHalfSize));
-            sceneSphere = core::vec4(cloudCenter, cloudHalfDiag);
-        }
-    }
-    float cameraOrbitLength = camera->zoomTo(sceneSphere);
+    auto gzitem_item = scene->createItem();
+    gzitem_item.setDrawable(gzdrawable_item);
+    auto gzitem = scene->createItem();
+    gzitem.setDrawable(gzdrawable);
+
+    scene->_nodes.updateTransforms();
+
+
+    scene->updateBounds();
+    core::vec4 sceneSphere = scene->getBounds().toSphere();
+    
+    // Content creation
+    float doAnimate = 0.0f;
+
+
+    // For user input, we can use a CameraController which will provide a standard manipulation of the camera from keyboard and mouse
+    auto camControl = std::make_shared< uix::CameraController >(camera);
+    float cameraOrbitLength = camControl->zoomTo(sceneSphere);
     camera->setFar(cameraOrbitLength * 100.0f);
     
  
@@ -209,9 +224,10 @@ int main(int argc, char *argv[])
     graphics::SwapchainInit swapchainInit { window->width(), window->height(), (HWND) window->nativeWindow(), true };
     auto swapchain = gpuDevice->createSwapchain(swapchainInit);
 
+
     //Now that we have created all the elements, 
     // We configure the windowHandler onPaint delegate of the window to do real rendering!
-    windowHandler->_onPaintDelegate = ([swapchain, viewport, window, camera, scene, rnode, bnode, cnode, dnode](const uix::PaintEvent& e) {
+    windowHandler->_onPaintDelegate = ([&](const uix::PaintEvent& e) {
         // Measuring framerate
         static core::FrameTimer::Sample frameSample;
         auto currentSample = viewport->lastFrameTimerSample();
@@ -226,30 +242,31 @@ int main(int argc, char *argv[])
         }
         auto t = acos(-1.0f) * (currentSample._frameNum / 300.0f);
 
-        // Move something
-        scene->_transformTree->editTransform(rnode.id(), [t] (core::mat4x3& rts) -> bool {
-            core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(t), 0.0f, sin(t)));
-            core::rotation(rts, rotor);
-            return true;
-        });
-        scene->_transformTree->editTransform(bnode.id(), [t](core::mat4x3& rts) -> bool {
-            
-            
-            return true;
-        });
-        scene->_transformTree->editTransform(cnode.id(), [t](core::mat4x3& rts) -> bool {
-            core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(0.2 * t), 0.0f, sin(0.2 * t)));
-            core::rotation(rts, rotor);
-            return true;
-        });
-        scene->_transformTree->editTransform(dnode.id(), [t](core::mat4x3& rts) -> bool {
-            core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(0.5 * t), sin(0.5 * t), 0.0f));
-            core::rotation(rts, rotor);
-            return true;
-        });
+        if (doAnimate) {
+            // Move something
+            scene->_nodes.editTransform(rnode.id(), [t] (core::mat4x3& rts) -> bool {
+                core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(t), 0.0f, sin(t)));
+                core::rotation(rts, rotor);
+                return true;
+            });
+            scene->_nodes.editTransform(bnode.id(), [t](core::mat4x3& rts) -> bool {
+                return true;
+            });
+            scene->_nodes.editTransform(cnode.id(), [t](core::mat4x3& rts) -> bool {
+                core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(0.2 * t), 0.0f, sin(0.2 * t)));
+                core::rotation(rts, rotor);
+                return true;
+            });
+            scene->_nodes.editTransform(dnode.id(), [t](core::mat4x3& rts) -> bool {
+                core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(0.5 * t), sin(0.5 * t), 0.0f));
+                core::rotation(rts, rotor);
+                return true;
+            });
+        }
 
-
-        scene->_transformTree->updateTransforms();
+        scene->_items.syncBuffer();
+        scene->_nodes.updateTransforms();
+        camControl->update(std::chrono::duration_cast<std::chrono::microseconds>(frameSample._frameDuration));
 
         // Render!
         viewport->present(swapchain);
@@ -262,14 +279,7 @@ int main(int argc, char *argv[])
             gpuDevice->resizeSwapchain(swapchain, e.width, e.height);
         }
 
-        // aspect ratio changes with a resize always
-        // viewport resolution, only once the resize is over
-        if (!e.over) {
-            camera->setAspectRatio(e.width / (float)e.height);
-        }
-        else {
-            camera->setViewport(e.width, e.height, true);
-        }
+        camControl->onResize(e);
     };
 
     windowHandler->_onKeyboardDelegate = [&](const uix::KeyboardEvent& e) {
@@ -321,11 +331,19 @@ int main(int argc, char *argv[])
         }
 
         if (zoomToScene) {
-            cameraOrbitLength = camera->zoomTo(sceneSphere);
+            camControl->zoomTo(sceneSphere);
+        }
+        if (camControl->onKeyboard(e)) {
+            return;
         }
     };
 
     windowHandler->_onMouseDelegate = [&](const uix::MouseEvent& e) {
+
+        if (camControl->onMouse(e)) {
+            return;
+        }
+
         if (e.state & uix::MOUSE_MOVE) {
             if (e.state & uix::MOUSE_LBUTTON) {
                 if (pointCloudDrawableFactory) {
@@ -357,39 +375,6 @@ int main(int argc, char *argv[])
                 if (camera->isOrtho()) {
                 } else {
                     camera->setFocal(camera->getProjectionHeight()* (ny* ny* ny));
-                }
-            }
-            if (e.state & uix::MOUSE_RBUTTON) {
-                if (e.state & uix::MOUSE_CONTROL) {
-                    float panScale = cameraOrbitLength * 0.001f;
-                    if (camera->isOrtho()) {
-                        panScale = camera->getOrthoHeight() / camera->getViewportHeight();
-                    } else {
-                    }    
-                    camera->pan(-e.delta.x * panScale, e.delta.y * panScale);
-                } else {
-                    float orbitScale = 0.01f;
-                    camera->orbit(cameraOrbitLength, orbitScale * (float)e.delta.x, orbitScale * (float)-e.delta.y);
-                }
-            }
-        } else if (e.state & uix::MOUSE_WHEEL) {
-            if (e.state & uix::MOUSE_CONTROL) {
-                if (camera->isOrtho()) {
-                    float dollyScale = 0.08f;
-                    float orbitLengthDelta = (e.wheel * dollyScale) * cameraOrbitLength;
-                    cameraOrbitLength = camera->boom(cameraOrbitLength, orbitLengthDelta);
-                } else {
-                    float zoomScale = 0.1f;
-                    camera->setFocal(camera->getFocal() * (1.0f +  e.wheel * zoomScale));
-                }
-            } else {
-                if (camera->isOrtho()) {
-                    float zoomScale = 0.1f;
-                    camera->setOrthoHeight(camera->getOrthoHeight() * (1.0f + e.wheel * zoomScale));
-                } else {
-                    float dollyScale = 0.08f;
-                    float orbitLengthDelta = (e.wheel * dollyScale) * cameraOrbitLength;
-                    cameraOrbitLength = camera->boom(cameraOrbitLength, orbitLengthDelta);
                 }
             }
         }

--- a/test/pico_04/pico_four.cpp
+++ b/test/pico_04/pico_four.cpp
@@ -119,9 +119,9 @@ int main(int argc, char *argv[])
     pointCloudDrawableFactory->allocateGPUShared(gpuDevice);
 
     // a drawable from the pointcloud
- //   graphics::PointCloudDrawablePointer pointCloudDrawable(pointCloudDrawableFactory->createPointCloudDrawable(gpuDevice, pointCloud));
-//    pointCloudDrawableFactory->allocateDrawcallObject(gpuDevice, camera, pointCloudDrawable);
-//    auto pcitem = scene->createItem(pointCloudDrawable);
+    graphics::PointCloudDrawablePointer pointCloudDrawable(pointCloudDrawableFactory->createPointCloudDrawable(gpuDevice, pointCloud));
+    pointCloudDrawableFactory->allocateDrawcallObject(gpuDevice, camera, pointCloudDrawable);
+    auto pcitem = scene->createItem(pointCloudDrawable);
 
     // A triangel soup drawable factory
     auto triangleSoupDrawableFactory = std::make_shared<graphics::TriangleSoupDrawableFactory>();

--- a/test/pico_04/pico_four.cpp
+++ b/test/pico_04/pico_four.cpp
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
 
     // a drawable from the pointcloud
     graphics::PointCloudDrawablePointer pointCloudDrawable(pointCloudDrawableFactory->createPointCloudDrawable(gpuDevice, pointCloud));
-    pointCloudDrawableFactory->allocateDrawcallObject(gpuDevice, camera, pointCloudDrawable);
+    pointCloudDrawableFactory->allocateDrawcallObject(gpuDevice, scene->_transformTree, camera, pointCloudDrawable);
     auto pcitem = scene->createItem(pointCloudDrawable);
 
     // A triangel soup drawable factory
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
 
     // a drawable from the trianglesoup
     graphics::TriangleSoupDrawablePointer triangleSoupDrawable(triangleSoupDrawableFactory->createTriangleSoupDrawable(gpuDevice, triangleSoup));
-    triangleSoupDrawableFactory->allocateDrawcallObject(gpuDevice, camera, triangleSoupDrawable);
+    triangleSoupDrawableFactory->allocateDrawcallObject(gpuDevice, scene->_transformTree, camera, triangleSoupDrawable);
     auto tsitem = scene->createItem(triangleSoupDrawable);
 
     // A gizmo drawable factory
@@ -145,18 +145,27 @@ int main(int argc, char *argv[])
     gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene->_transformTree, camera, gizmoDrawable);
     auto gitem = scene->createItem(gizmoDrawable);
 
-    auto rnode = scene->createNode(core::mat4x3::translation(core::vec3(4.0f, 0.0f, 0.0f)), -1);
+    auto node0 = scene->createNode(core::mat4x3(), -1);
+   
+     auto rnode = scene->createNode(core::translation(core::vec3(4.0f, 0.0f, 0.0f)), node0);
 
-    auto bnode = scene->createNode(core::mat4x3::translation(core::vec3(8.0f, 0.0f, 0.0f)), rnode);
+    auto bnode = scene->createNode(core::translation(core::vec3(8.0f, 0.0f, 0.0f)), rnode);
 
-    auto cnode = scene->createNode(core::mat4x3::translation(core::vec3(0.0f, 5.0f, 0.0f)), bnode);
+    auto cnode = scene->createNode(core::translation(core::vec3(0.0f, 5.0f, 0.0f)), bnode);
 
-    auto dnode = scene->createNode(core::mat4x3::translation(core::vec3(0.0f, 0.0f, 3.0f)), cnode);
+    auto dnode = scene->createNode(core::translation(core::vec3(0.0f, 0.0f, 3.0f)), cnode);
  
     gizmoDrawable->nodes.push_back(rnode);
     gizmoDrawable->nodes.push_back(bnode);
     gizmoDrawable->nodes.push_back(cnode);
     gizmoDrawable->nodes.push_back(dnode);
+
+    auto pcitem2 = scene->createItem(pointCloudDrawable);
+
+    tsitem.setNode(bnode);
+    pcitem.setNode(node0);
+    pcitem2.setNode(dnode);
+
 
     // Content creation
     float doAnimate = 1.0f;
@@ -213,10 +222,8 @@ int main(int argc, char *argv[])
 
         // Move something
         scene->_transformTree->editTransform(rnode, [t] (core::mat4x3& rts) -> bool {
-            auto ori = rts._columns[3];
             core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(t), 0.0f, sin(t)));
-            rts = rotor.toMat4x3();
-            rts._columns[3] = ori;
+            core::rotation(rts, rotor);
             return true;
         });
         scene->_transformTree->editTransform(bnode, [t](core::mat4x3& rts) -> bool {
@@ -225,23 +232,13 @@ int main(int argc, char *argv[])
             return true;
         });
         scene->_transformTree->editTransform(cnode, [t](core::mat4x3& rts) -> bool {
-            auto ori = rts._columns[3];
-
             core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(0.2 * t), 0.0f, sin(0.2 * t)));
-            rts = rotor.toMat4x3();
-
-            rts._columns[3] = ori;
-
+            core::rotation(rts, rotor);
             return true;
         });
         scene->_transformTree->editTransform(dnode, [t](core::mat4x3& rts) -> bool {
-            auto ori = rts._columns[3];
-
             core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(0.5 * t), sin(0.5 * t), 0.0f));
-            rts = rotor.toMat4x3();
-
-            rts._columns[3] = ori;
-
+            core::rotation(rts, rotor);
             return true;
         });
 

--- a/test/pico_04/pico_four.cpp
+++ b/test/pico_04/pico_four.cpp
@@ -147,25 +147,31 @@ int main(int argc, char *argv[])
 
     auto node0 = scene->createNode(core::mat4x3(), -1);
    
-     auto rnode = scene->createNode(core::translation(core::vec3(4.0f, 0.0f, 0.0f)), node0);
+     auto rnode = scene->createNode(core::translation(core::vec3(4.0f, 0.0f, 0.0f)), node0.id());
 
-    auto bnode = scene->createNode(core::translation(core::vec3(8.0f, 0.0f, 0.0f)), rnode);
+    auto bnode = scene->createNode(core::translation(core::vec3(8.0f, 0.0f, 0.0f)), rnode.id());
 
-    auto cnode = scene->createNode(core::translation(core::vec3(0.0f, 5.0f, 0.0f)), bnode);
+    auto cnode = scene->createNode(core::translation(core::vec3(0.0f, 5.0f, 0.0f)), bnode.id());
 
-    auto dnode = scene->createNode(core::translation(core::vec3(0.0f, 0.0f, 3.0f)), cnode);
- 
-    gizmoDrawable->nodes.push_back(rnode);
-    gizmoDrawable->nodes.push_back(bnode);
-    gizmoDrawable->nodes.push_back(cnode);
-    gizmoDrawable->nodes.push_back(dnode);
+    auto dnode = scene->createNode(core::translation(core::vec3(0.0f, 0.0f, 3.0f)), cnode.id());
+
+    auto enode = scene->createNode(core::translation(core::vec3(0.0f, 1.0f, 4.0f)), rnode.id());
+
+
+    gizmoDrawable->nodes.push_back(node0.id());
+    gizmoDrawable->nodes.push_back(rnode.id());
+    gizmoDrawable->nodes.push_back(bnode.id());
+    gizmoDrawable->nodes.push_back(cnode.id());
+    gizmoDrawable->nodes.push_back(dnode.id());
+    gizmoDrawable->nodes.push_back(enode.id());
 
     auto pcitem2 = scene->createItem(pointCloudDrawable);
+    auto tsitem2 = scene->createItem(triangleSoupDrawable);
 
-    tsitem.setNode(bnode);
+    tsitem.setNode(enode);
     pcitem.setNode(node0);
-    pcitem2.setNode(dnode);
-
+// pcitem2.setNode(dnode);
+    tsitem2.setNode(dnode);
 
     // Content creation
     float doAnimate = 1.0f;
@@ -221,22 +227,22 @@ int main(int argc, char *argv[])
         auto t = acos(-1.0f) * (currentSample._frameNum / 300.0f);
 
         // Move something
-        scene->_transformTree->editTransform(rnode, [t] (core::mat4x3& rts) -> bool {
+        scene->_transformTree->editTransform(rnode.id(), [t] (core::mat4x3& rts) -> bool {
             core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(t), 0.0f, sin(t)));
             core::rotation(rts, rotor);
             return true;
         });
-        scene->_transformTree->editTransform(bnode, [t](core::mat4x3& rts) -> bool {
+        scene->_transformTree->editTransform(bnode.id(), [t](core::mat4x3& rts) -> bool {
             
             
             return true;
         });
-        scene->_transformTree->editTransform(cnode, [t](core::mat4x3& rts) -> bool {
+        scene->_transformTree->editTransform(cnode.id(), [t](core::mat4x3& rts) -> bool {
             core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(0.2 * t), 0.0f, sin(0.2 * t)));
             core::rotation(rts, rotor);
             return true;
         });
-        scene->_transformTree->editTransform(dnode, [t](core::mat4x3& rts) -> bool {
+        scene->_transformTree->editTransform(dnode.id(), [t](core::mat4x3& rts) -> bool {
             core::rotor3 rotor(core::vec3(1.0f, 0.0f, 0.0f), core::vec3(cos(0.5 * t), sin(0.5 * t), 0.0f));
             core::rotation(rts, rotor);
             return true;


### PR DESCRIPTION
- introducing the index table
- introducing the transform tree
- introducing the aabox
- fixing several of the mat / vec / rotor / aabox transform functions
- fixing similar transform in the shaders, should be the same everywhere
- Made the Drawable the indexed customizable object that can be drawn as multiple instance
- Made the item a simpler struct referencing together the transform node and a drawable allowing for instancing
- Added a gizmoDrawable to debug and represent the scene nodes/items/drawables
- brought the keyboards and mouse behaviors from the pico four into the CameraController and make it helpful

we now have a clean architecture for the scene:
Nodes are linked together and define a hierarchy, a tree of relative transforms.  
Drawables are objects that can be drawn and reused at multiple location in the scene.
Items are unique instances of "thing" in the scene, an item reference a nodeID, and a drawableID and voila

Pretty happy with this new design, now let s make something with it
 
