### PR TITLE
re-arch  of descriptor and descriptor heap, update code base

### DIFF
--- a/src/core/stl/IndexTable.h
+++ b/src/core/stl/IndexTable.h
@@ -40,9 +40,10 @@ namespace core {
         using Indices = std::vector<Index>;
         static const Index INVALID_INDEX{ (Index) -1 };
 
-        IndexTable() {}
+        IndexTable(Index capacity = (Index)-1) : _capacity(capacity) {}
         ~IndexTable() {}
 
+        Index getCapacity() const { return _capacity; }
         Index getNumElements() const { return _num_allocated_elements - (Index) _invalid_elements.size(); }
         Index getNumAllocatedElements() const { return _num_allocated_elements; }
 
@@ -78,6 +79,15 @@ namespace core {
             return std::move(allocated);
         }
 
+        Index allocateContiguous(Index num_elements) {
+            Index new_index = _num_allocated_elements;
+            if (new_index + num_elements < getCapacity()) {
+                _num_allocated_elements += num_elements;
+                return new_index;
+            }
+            return INVALID_INDEX;
+        }
+
         void free(Index index) {
             _invalid_elements.push_back(index);
         }
@@ -89,7 +99,7 @@ namespace core {
     private:
         Index _num_allocated_elements{ (Index) 0 };
         std::vector<Index> _invalid_elements;
-
+        const Index _capacity{ (Index) -1 };
     };
 
 }

--- a/src/graphics/d3d12/D3D12Backend.cpp
+++ b/src/graphics/d3d12/D3D12Backend.cpp
@@ -377,8 +377,12 @@ D3D12Backend::D3D12Backend() {
     _fence = CreateFence(_device);
     _fenceEvent = CreateEventHandle();
 
-    // Allocate a global descriptor heap
-    _descriptorHeap = CreateDescriptorHeap();
+    // Allocate a global descriptor heap referenced form this backend
+    DescriptorHeapInit descriptorHeapInit {
+        10000,
+        1000
+    };
+    _descriptorHeap = this->createDescriptorHeap(descriptorHeapInit);
 }
 
 D3D12Backend::~D3D12Backend() {

--- a/src/graphics/d3d12/D3D12Backend_Pipeline.cpp
+++ b/src/graphics/d3d12/D3D12Backend_Pipeline.cpp
@@ -57,8 +57,8 @@ bool D3D12Backend::realizePipelineState(PipelineState* pipeline) {
         // Create an empty root signature if none provided.
         if (pso->_rootSignature) {
             rootSignature = pso->_rootSignature;
-        } else if (init.descriptorSetLayout) {
-            auto dxDescLayout = static_cast<D3D12DescriptorSetLayoutBackend*> (init.descriptorSetLayout.get());
+        } else if (init.rootDescriptorLayout) {
+            auto dxDescLayout = static_cast<D3D12RootDescriptorLayoutBackend*> (init.rootDescriptorLayout.get());
             rootSignature = dxDescLayout->_rootSignature;
         }
         else {
@@ -155,8 +155,8 @@ bool D3D12Backend::realizePipelineState(PipelineState* pipeline) {
         if (pso->_rootSignature) {
             rootSignature = pso->_rootSignature;
         }
-        else if (init.descriptorSetLayout) {
-            auto dxDescLayout = static_cast<D3D12DescriptorSetLayoutBackend*> (init.descriptorSetLayout.get());
+        else if (init.rootDescriptorLayout) {
+            auto dxDescLayout = static_cast<D3D12RootDescriptorLayoutBackend*> (init.rootDescriptorLayout.get());
             rootSignature = dxDescLayout->_rootSignature;
         }
         else {
@@ -204,7 +204,7 @@ PipelineStatePointer D3D12Backend::createGraphicsPipelineState(const GraphicsPip
     pso->_type = PipelineType::GRAPHICS;
     pso->_graphics = init;
     pso->_program = init.program;
-    pso->_descriptorSetLayout = init.descriptorSetLayout;
+    pso->_rootDescriptorLayout = init.rootDescriptorLayout;
 
     if (realizePipelineState(pso.get())) {
 
@@ -227,7 +227,7 @@ PipelineStatePointer D3D12Backend::createComputePipelineState(const ComputePipel
     pso->_type = PipelineType::COMPUTE;
     pso->_compute = init;
     pso->_program = init.program;
-    pso->_descriptorSetLayout = init.descriptorSetLayout;
+    pso->_rootDescriptorLayout = init.rootDescriptorLayout;
 
 
     if (realizePipelineState(pso.get())) {

--- a/src/graphics/drawables/HeightmapDrawable.cpp
+++ b/src/graphics/drawables/HeightmapDrawable.cpp
@@ -73,15 +73,17 @@ namespace graphics
     void HeightmapDrawableFactory::allocateGPUShared(const graphics::DevicePointer& device) {
 
         // Let's describe the pipeline Descriptors layout
-        graphics::DescriptorLayouts descriptorLayouts{
-            { graphics::DescriptorType::UNIFORM_BUFFER, graphics::ShaderStage::ALL_GRAPHICS, 0, 1},
-            { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(HeightmapObjectData) >> 2},
-            { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
-            { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 1, 1},
+        graphics::RootDescriptorLayoutInit rootLayoutInit{ 
+            { // Push uniforms layout
+                { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(HeightmapObjectData) >> 2}
+            },
+            {{ // Descriptor set Layouts
+                { graphics::DescriptorType::UNIFORM_BUFFER, graphics::ShaderStage::ALL_GRAPHICS, 0, 1},
+                { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
+                { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 1, 1}
+            }}
         };
-
-        graphics::DescriptorSetLayoutInit descriptorSetLayoutInit{ descriptorLayouts };
-        auto descriptorSetLayout = device->createDescriptorSetLayout(descriptorSetLayoutInit);
+        auto rootDescriptorLayout = device->createRootDescriptorLayout(rootLayoutInit);
 
         // And a Pipeline
 
@@ -97,9 +99,9 @@ namespace graphics
 
         graphics::GraphicsPipelineStateInit pipelineInit{
                     programShader,
+                    rootDescriptorLayout,
                     StreamLayout(),
                     graphics::PrimitiveTopology::TRIANGLE_STRIP,
-                    descriptorSetLayout,
                     RasterizerState(),
                     true, // enable depth
                     BlendState()
@@ -110,19 +112,22 @@ namespace graphics
 
         {
             // Let's describe the Compute pipeline Descriptors layout
-            graphics::DescriptorLayouts computeDescriptorLayouts{
-                { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::COMPUTE, 1, sizeof(HeightmapObjectData) >> 2},
-                { graphics::DescriptorType::RW_RESOURCE_BUFFER, graphics::ShaderStage::COMPUTE, 0, 1},
+            graphics::RootDescriptorLayoutInit computeDescriptorLayoutInit{
+                { // Push uniforms layout
+                    { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::COMPUTE, 1, sizeof(HeightmapObjectData) >> 2}
+                },
+                {{ // Descriptor set Layouts
+                    { graphics::DescriptorType::RW_RESOURCE_BUFFER, graphics::ShaderStage::COMPUTE, 0, 1},
+                }}
             };
-            graphics::DescriptorSetLayoutInit compDescriptorSetLayoutInit{ computeDescriptorLayouts };
-            auto compDescriptorSetLayout = device->createDescriptorSetLayout(compDescriptorSetLayoutInit);
+            auto compRootDescriptorLayout = device->createRootDescriptorLayout(computeDescriptorLayoutInit);
 
             graphics::ShaderInit compShaderInit{ graphics::ShaderType::COMPUTE, "main", "", Ocean_comp::getSource(), Ocean_comp::getSourceFilename() };
             graphics::ShaderPointer compShader = device->createShader(compShaderInit);
 
             graphics::ComputePipelineStateInit computePipelineInit{
                 compShader,
-                compDescriptorSetLayout
+                compRootDescriptorLayout
             };
 
             _computePipeline = device->createComputePipelineState(computePipelineInit);
@@ -166,39 +171,31 @@ namespace graphics
        // It s time to create a descriptorSet that matches the expected pipeline descriptor set
        // then we will assign a uniform buffer in it
        graphics::DescriptorSetInit compDescriptorSetInit{
-           _computePipeline->getDescriptorSetLayout()
+           _computePipeline->getRootDescriptorLayout(),
+           0
        };
        auto compDescriptorSet = device->createDescriptorSet(compDescriptorSetInit);
 
        if (doCompute) {
-           graphics::DescriptorObject compute_wrboDescriptorObject;
-           compute_wrboDescriptorObject._buffers.push_back(drawable.getHeightBuffer());
-           graphics::DescriptorObjects compute_descriptorObjects = {
-                compute_wrboDescriptorObject
-           };
+           graphics::DescriptorObjects compute_descriptorObjects = {{
+                { graphics::DescriptorType::RW_RESOURCE_BUFFER, drawable.getHeightBuffer() }
+           }};
            device->updateDescriptorSet(compDescriptorSet, compute_descriptorObjects);
        }
 
         // It s time to create a descriptorSet that matches the expected pipeline descriptor set
         // then we will assign a uniform buffer in it
         graphics::DescriptorSetInit descriptorSetInit{
-            _HeightmapPipeline->getDescriptorSetLayout()
+            _HeightmapPipeline->getRootDescriptorLayout(),
+            0
         };
         auto descriptorSet = device->createDescriptorSet(descriptorSetInit);
 
         // Assign the Camera UBO just created as the resource of the descriptorSet
-        // auto descriptorObjects = descriptorSet->buildDescriptorObjects();
-        graphics::DescriptorObject camera_uboDescriptorObject;
-        camera_uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
-        graphics::DescriptorObject transform_rboDescriptorObject;
-        transform_rboDescriptorObject._buffers.push_back(scene->_nodes._transforms_buffer);
-        graphics::DescriptorObject heightmap_rboDescriptorObject;
-        heightmap_rboDescriptorObject._buffers.push_back(drawable.getHeightBuffer());
-
         graphics::DescriptorObjects descriptorObjects = {
-            camera_uboDescriptorObject,
-            transform_rboDescriptorObject,
-            heightmap_rboDescriptorObject
+           { graphics::DescriptorType::UNIFORM_BUFFER, camera->getGPUBuffer() },
+           { graphics::DescriptorType::RESOURCE_BUFFER, scene->_nodes._transforms_buffer },
+           { graphics::DescriptorType::RESOURCE_BUFFER, drawable.getHeightBuffer() }
         };
         device->updateDescriptorSet(descriptorSet, descriptorObjects);
         auto compute_pipeline = this->_computePipeline;
@@ -227,7 +224,7 @@ namespace graphics
             odata.nodeID = node;
             batch->bindPipeline(pipeline);
             batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, descriptorSet);
-            batch->bindPushUniform(graphics::PipelineType::GRAPHICS, 1, sizeof(HeightmapObjectData), (const uint8_t*)&odata);
+            batch->bindPushUniform(graphics::PipelineType::GRAPHICS, 0, sizeof(HeightmapObjectData), (const uint8_t*)&odata);
 
             // A heightmap is drawn with triangle strips patch of (2 * (width + 1) + 1) * (height) verts
             batch->draw(heightmap->_heightmap.getMeshNumIndices(), 0);

--- a/src/graphics/drawables/PointcloudDrawable.cpp
+++ b/src/graphics/drawables/PointcloudDrawable.cpp
@@ -68,16 +68,17 @@ namespace graphics
 
     void PointCloudDrawableFactory::allocateGPUShared(const graphics::DevicePointer& device) {
 
-        // Let's describe the pipeline Descriptors layout
-        graphics::DescriptorLayouts descriptorLayouts{
+        graphics::RootDescriptorLayoutInit descriptorLayoutInit{
+            {
+            { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(PCObjectData) >> 2}
+            },
+            {{
             { graphics::DescriptorType::UNIFORM_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
-            { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(PCObjectData) >> 2},
             { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
             { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 1, 1},
+            }}
         };
-
-        graphics::DescriptorSetLayoutInit descriptorSetLayoutInit{ descriptorLayouts };
-        auto descriptorSetLayout = device->createDescriptorSetLayout(descriptorSetLayoutInit);
+        auto rootDescriptorLayout = device->createRootDescriptorLayout(descriptorLayoutInit);
 
         // And a Pipeline
 
@@ -106,9 +107,9 @@ namespace graphics
       */
         graphics::GraphicsPipelineStateInit pipelineInit{
                     programShader,
+                    rootDescriptorLayout,
                     StreamLayout(),
                     graphics::PrimitiveTopology::TRIANGLE,
-                    descriptorSetLayout,
                     RasterizerState(),
                     true, // enable depth
                     { graphics::BlendFunction(true,
@@ -178,21 +179,16 @@ namespace graphics
         // It s time to create a descriptorSet that matches the expected pipeline descriptor set
         // then we will assign a uniform buffer in it
         graphics::DescriptorSetInit descriptorSetInit{
-            _pipeline->getDescriptorSetLayout()
+            _pipeline->getRootDescriptorLayout(),
+            0
         };
         auto descriptorSet = device->createDescriptorSet(descriptorSetInit);
 
         // Assign the Camera UBO just created as the resource of the descriptorSet
-        // auto descriptorObjects = descriptorSet->buildDescriptorObjects();
-        graphics::DescriptorObject camera_uboDescriptorObject;
-        camera_uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
-        graphics::DescriptorObject transform_rboDescriptorObject;
-        transform_rboDescriptorObject._buffers.push_back(scene->_nodes._transforms_buffer);
-        graphics::DescriptorObject mesh_rboDescriptorObject;
-        mesh_rboDescriptorObject._buffers.push_back(pointcloud.getVertexBuffer());
-
         graphics::DescriptorObjects descriptorObjects = {
-            camera_uboDescriptorObject, transform_rboDescriptorObject, mesh_rboDescriptorObject
+           { graphics::DescriptorType::UNIFORM_BUFFER, camera->getGPUBuffer() },
+           { graphics::DescriptorType::RESOURCE_BUFFER, scene->_nodes._transforms_buffer },
+           { graphics::DescriptorType::RESOURCE_BUFFER, pointcloud.getVertexBuffer() }
         };
         device->updateDescriptorSet(descriptorSet, descriptorObjects);
 
@@ -212,7 +208,7 @@ namespace graphics
 
             auto uniforms = ppointcloud->getUniforms();
             PCObjectData odata { { (int32_t) node }, uniforms->spriteSize, uniforms->perspectiveSprite, uniforms->perspectiveDepth, uniforms->showPerspectiveDepthPlane };
-            batch->bindPushUniform(graphics::PipelineType::GRAPHICS, 1, sizeof(PCObjectData), (const uint8_t*) &odata);
+            batch->bindPushUniform(graphics::PipelineType::GRAPHICS, 0, sizeof(PCObjectData), (const uint8_t*) &odata);
 
             batch->draw(3 * numVertices, 0);
         };

--- a/src/graphics/drawables/PrimitiveDrawable.cpp
+++ b/src/graphics/drawables/PrimitiveDrawable.cpp
@@ -67,14 +67,16 @@ namespace graphics
     void PrimitiveDrawableFactory::allocateGPUShared(const graphics::DevicePointer& device) {
 
         // Let's describe the pipeline Descriptors layout
-        graphics::DescriptorLayouts descriptorLayouts{
+        graphics::RootDescriptorLayoutInit rootLayoutInit{
+            {
+            { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(PrimitiveObjectData) >> 2}
+            },
+            {{
             { graphics::DescriptorType::UNIFORM_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
-            { graphics::DescriptorType::PUSH_UNIFORM, graphics::ShaderStage::VERTEX, 1, sizeof(PrimitiveObjectData) >> 2},
             { graphics::DescriptorType::RESOURCE_BUFFER, graphics::ShaderStage::VERTEX, 0, 1},
-        };
-
-        graphics::DescriptorSetLayoutInit descriptorSetLayoutInit{ descriptorLayouts };
-        auto descriptorSetLayout = device->createDescriptorSetLayout(descriptorSetLayoutInit);
+            }}
+         };
+        auto rootDescriptorLayout = device->createRootDescriptorLayout(rootLayoutInit);
 
         // And a Pipeline
 
@@ -90,9 +92,9 @@ namespace graphics
 
         graphics::GraphicsPipelineStateInit pipelineInit{
                     programShader,
+                    rootDescriptorLayout,
                     StreamLayout(),
                     graphics::PrimitiveTopology::TRIANGLE,
-                    descriptorSetLayout,
                     RasterizerState(),
                     true, // enable depth
                     BlendState()
@@ -115,19 +117,15 @@ namespace graphics
         // It s time to create a descriptorSet that matches the expected pipeline descriptor set
         // then we will assign a uniform buffer in it
         graphics::DescriptorSetInit descriptorSetInit{
-            _primitivePipeline->getDescriptorSetLayout()
+            _primitivePipeline->getRootDescriptorLayout(),
+            0
         };
         auto descriptorSet = device->createDescriptorSet(descriptorSetInit);
 
         // Assign the Camera UBO just created as the resource of the descriptorSet
-        // auto descriptorObjects = descriptorSet->buildDescriptorObjects();
-        graphics::DescriptorObject camera_uboDescriptorObject;
-        camera_uboDescriptorObject._uniformBuffers.push_back(camera->getGPUBuffer());
-        graphics::DescriptorObject transform_rboDescriptorObject;
-        transform_rboDescriptorObject._buffers.push_back(scene->_nodes._transforms_buffer);
         graphics::DescriptorObjects descriptorObjects = {
-            camera_uboDescriptorObject,
-            transform_rboDescriptorObject
+            { graphics::DescriptorType::UNIFORM_BUFFER, camera->getGPUBuffer() },
+            { graphics::DescriptorType::RESOURCE_BUFFER, scene->_nodes._transforms_buffer }
         };
         device->updateDescriptorSet(descriptorSet, descriptorObjects);
 
@@ -143,7 +141,7 @@ namespace graphics
             batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, descriptorSet);
 
             PrimitiveObjectData odata{ node, prim_->_size.x * 0.5f, prim_->_size.y * 0.5f, prim_->_size.z * 0.5f };
-            batch->bindPushUniform(graphics::PipelineType::GRAPHICS, 1, sizeof(PrimitiveObjectData), (const uint8_t*)&odata);
+            batch->bindPushUniform(graphics::PipelineType::GRAPHICS, 0, sizeof(PrimitiveObjectData), (const uint8_t*)&odata);
 
             // A box is 6 faces * 2 trianglestrip * 4 verts + -1
             batch->draw(6 * 2 * 3, 0);

--- a/src/graphics/gpu/Batch.cpp
+++ b/src/graphics/gpu/Batch.cpp
@@ -62,6 +62,7 @@ void Batch::setScissor(const core::vec4& scissor) {}
 
 void Batch::bindFramebuffer(const FramebufferPointer& framebuffer) {}
 
+void Batch::bindRootDescriptorLayout(PipelineType type, const RootDescriptorLayoutPointer& rootLayout) {}
 void Batch::bindPipeline(const PipelineStatePointer& pipeline) {}
 void Batch::bindDescriptorSet(PipelineType type, const DescriptorSetPointer& descriptorSet) {}
 void Batch::bindPushUniform(PipelineType type, uint32_t slot, uint32_t size, const uint8_t* data) {}

--- a/src/graphics/gpu/Batch.h
+++ b/src/graphics/gpu/Batch.h
@@ -72,7 +72,9 @@ namespace graphics {
 
         virtual void bindFramebuffer(const FramebufferPointer& framebuffer);
 
+        virtual void bindRootDescriptorLayout(PipelineType type, const RootDescriptorLayoutPointer& rootDescriptorLayout);
         virtual void bindPipeline(const PipelineStatePointer& pipeline);
+
         virtual void bindDescriptorSet(PipelineType type, const DescriptorSetPointer& descriptorSet);
         virtual void bindPushUniform(PipelineType type, uint32_t slot, uint32_t size, const uint8_t* data);
 

--- a/src/graphics/gpu/Descriptor.cpp
+++ b/src/graphics/gpu/Descriptor.cpp
@@ -28,19 +28,11 @@
 
 using namespace graphics;
 
-DescriptorSetLayout::DescriptorSetLayout() {
+RootDescriptorLayout::RootDescriptorLayout() {
 
 }
 
-DescriptorSetLayout::~DescriptorSetLayout() {
-
-}
-
-RootDescriptorsLayout::RootDescriptorsLayout() {
-
-}
-
-RootDescriptorsLayout::~RootDescriptorsLayout() {
+RootDescriptorLayout::~RootDescriptorLayout() {
 
 }
 
@@ -49,5 +41,13 @@ DescriptorSet::DescriptorSet() {
 }
 
 DescriptorSet::~DescriptorSet() {
+
+}
+
+DescriptorHeap::DescriptorHeap() {
+
+}
+
+DescriptorHeap::~DescriptorHeap() {
 
 }

--- a/src/graphics/gpu/Device.cpp
+++ b/src/graphics/gpu/Device.cpp
@@ -86,9 +86,16 @@ PipelineStatePointer Device::createComputePipelineState(const ComputePipelineSta
     return _backend->createComputePipelineState(init);
 }
 
-DescriptorSetLayoutPointer Device::createDescriptorSetLayout(const DescriptorSetLayoutInit& init) {
-    return _backend->createDescriptorSetLayout(init);
+RootDescriptorLayoutPointer Device::createRootDescriptorLayout(const RootDescriptorLayoutInit& init) {
+    return _backend->createRootDescriptorLayout(init);
 }
+DescriptorHeapPointer Device::createDescriptorHeap(const DescriptorHeapInit& init) {
+    return _backend->createDescriptorHeap(init);
+}
+DescriptorHeapPointer Device::getDescriptorHeap() {
+    return _backend->getDescriptorHeap();
+}
+
 DescriptorSetPointer Device::createDescriptorSet(const DescriptorSetInit& init) {
     return _backend->createDescriptorSet(init);
 }

--- a/src/graphics/gpu/Device.h
+++ b/src/graphics/gpu/Device.h
@@ -59,8 +59,13 @@ namespace graphics {
         virtual PipelineStatePointer createGraphicsPipelineState(const GraphicsPipelineStateInit& init) = 0;
         virtual PipelineStatePointer createComputePipelineState(const ComputePipelineStateInit& init) = 0;
 
-        virtual DescriptorSetLayoutPointer createDescriptorSetLayout(const DescriptorSetLayoutInit& init) = 0;
+        virtual RootDescriptorLayoutPointer createRootDescriptorLayout(const RootDescriptorLayoutInit& init) = 0;
+        
+        virtual DescriptorHeapPointer createDescriptorHeap(const DescriptorHeapInit& init) = 0;
+        virtual DescriptorHeapPointer getDescriptorHeap() = 0;
+
         virtual DescriptorSetPointer createDescriptorSet(const DescriptorSetInit& init) = 0;
+
         virtual void updateDescriptorSet(DescriptorSetPointer& descriptorSet, DescriptorObjects& objects) = 0;
 
         virtual void executeBatch(const BatchPointer& batch) = 0;
@@ -103,7 +108,11 @@ namespace graphics {
         PipelineStatePointer createGraphicsPipelineState(const GraphicsPipelineStateInit& init);
         PipelineStatePointer createComputePipelineState(const ComputePipelineStateInit& init);
 
-        DescriptorSetLayoutPointer createDescriptorSetLayout(const DescriptorSetLayoutInit& init);
+        RootDescriptorLayoutPointer createRootDescriptorLayout(const RootDescriptorLayoutInit& init);
+
+        DescriptorHeapPointer createDescriptorHeap(const DescriptorHeapInit& init);
+        DescriptorHeapPointer getDescriptorHeap();
+
         DescriptorSetPointer createDescriptorSet(const DescriptorSetInit& init);
 
         // Operations

--- a/src/graphics/gpu/Pipeline.cpp
+++ b/src/graphics/gpu/Pipeline.cpp
@@ -40,20 +40,12 @@ PipelineState::~PipelineState() {
 
 }
 
-Sampler::Sampler() {
-
-}
-
-Sampler::~Sampler() {
-
-}
-
 PipelineType PipelineState::getType() const {
     return _type;
 }
 
-DescriptorSetLayoutPointer PipelineState::getDescriptorSetLayout() const {
-    return _descriptorSetLayout;
+RootDescriptorLayoutPointer PipelineState::getRootDescriptorLayout() const {
+    return _rootDescriptorLayout;
 }
 
 bool PipelineState::realize() {

--- a/src/graphics/gpu/Pipeline.h
+++ b/src/graphics/gpu/Pipeline.h
@@ -38,9 +38,10 @@ namespace graphics {
 
     struct VISUALIZATION_API GraphicsPipelineStateInit {
         ShaderPointer program;
+        RootDescriptorLayoutPointer rootDescriptorLayout;
+
         StreamLayout streamLayout;
         PrimitiveTopology primitiveTopology{ PrimitiveTopology::POINT };
-        DescriptorSetLayoutPointer descriptorSetLayout;
         RasterizerState rasterizer;
         DepthStencilState depthStencil;
         BlendState blend;
@@ -53,7 +54,7 @@ namespace graphics {
 
     struct VISUALIZATION_API ComputePipelineStateInit {
         ShaderPointer program;
-        DescriptorSetLayoutPointer descriptorSetLayout;
+        RootDescriptorLayoutPointer rootDescriptorLayout;
         
         std::string watch_name;
     };
@@ -72,7 +73,7 @@ namespace graphics {
 
 
         ShaderPointer _program;
-        DescriptorSetLayoutPointer _descriptorSetLayout;
+        RootDescriptorLayoutPointer _rootDescriptorLayout;
 
         PipelineRealizer _pipelineRealizer;
 
@@ -85,8 +86,7 @@ namespace graphics {
         virtual ~PipelineState();
 
         PipelineType getType() const;
-        DescriptorSetLayoutPointer getDescriptorSetLayout() const;
-
+        RootDescriptorLayoutPointer getRootDescriptorLayout() const;
 
         bool realize();
 

--- a/src/graphics/gpu/gpu.h
+++ b/src/graphics/gpu/gpu.h
@@ -190,9 +190,13 @@ namespace graphics {
     struct ShaderInit;
     struct ProgramInit;
 
-    class DescriptorSetLayout;
-    using DescriptorSetLayoutPointer = std::shared_ptr<DescriptorSetLayout>;
-    struct DescriptorSetLayoutInit;
+    class RootDescriptorLayout;
+    using RootDescriptorLayoutPointer = std::shared_ptr<RootDescriptorLayout>;
+    struct RootDescriptorLayoutInit;
+
+    class DescriptorHeap;
+    using DescriptorHeapPointer = std::shared_ptr<DescriptorHeap>;
+    struct DescriptorHeapInit;
 
     class DescriptorSet;
     using DescriptorSetPointer = std::shared_ptr<DescriptorSet>;
@@ -262,8 +266,6 @@ namespace graphics {
         UNIFORM_BUFFER,            // CBV | VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
         RESOURCE_BUFFER,        // SRV | VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
         RW_RESOURCE_BUFFER,        // UAV | VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
-        UNIFORM_TEXEL_BUFFER_SRV,  // SRV | VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER
-        STORAGE_TEXEL_BUFFER_UAV,  // UAV | VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER
         RESOURCE_TEXTURE,               // SRV | VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
         RW_RESOURCE_TEXTURE,               // UAV | VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
         PUSH_UNIFORM,             // CONSTANT | PUSH_CONSTANT

--- a/test/pico_02/pico_two.cpp
+++ b/test/pico_02/pico_two.cpp
@@ -115,7 +115,7 @@ graphics::PipelineStatePointer createPipelineState(const graphics::DevicePointer
 
 
 
-    graphics::GraphicsPipelineStateInit pipelineInit { programShader,  streamLayout, graphics::PrimitiveTopology::TRIANGLE };
+    graphics::GraphicsPipelineStateInit pipelineInit { programShader, nullptr, streamLayout, graphics::PrimitiveTopology::TRIANGLE };
     graphics::PipelineStatePointer pipeline = device->createGraphicsPipelineState(pipelineInit);
 
     return pipeline;

--- a/test/pico_model/pico_model.cpp
+++ b/test/pico_model/pico_model.cpp
@@ -99,8 +99,8 @@ graphics::NodeIDs generateModel(graphics::DevicePointer& gpuDevice, graphics::Sc
    //  std::string modelFile("../asset/gltf/Castle Parapet Wall_sbxuw_3D Asset/Castle Parapet Wall_LOD0__sbxuw.gltf");
    // std::string modelFile("../asset/gltf/Half Avocado_ujcxeblva_3D Asset/Half Avocado_LOD0__ujcxeblva.gltf");
 
-   //std::string modelFile("C:\\Megascans/Pico/Banana_vfendgyiw/Banana_LOD0__vfendgyiw.gltf");
-   std::string modelFile("C:\\Megascans/Pico/Nordic Beach Rock_uknoehp/Nordic Beach Rock_LOD0__uknoehp.gltf");
+   std::string modelFile("C:\\Megascans/Pico/Banana_vfendgyiw/Banana_LOD0__vfendgyiw.gltf");
+   //std::string modelFile("C:\\Megascans/Pico/Nordic Beach Rock_uknoehp/Nordic Beach Rock_LOD0__uknoehp.gltf");
 
   // std::string modelFile("C:\\Megascans/Pico/Test-fbx_f48bbc8f-9166-9bc4-fbfb-688a71b1baa7/Test-fbx_LOD0__f48bbc8f-9166-9bc4-fbfb-688a71b1baa7.gltf");
    // std::string modelFile("C:\\Megascans/Pico/Wooden Chair_uknjbb2bw/Wooden Chair_LOD0__uknjbb2bw.gltf");


### PR DESCRIPTION
update all the code base with the new api for root descriptor layout and descriptor heap and descriptor set

it is not over yet, but at least everything is working correctly with the current state:
1/ RootDescriptorLayout is the only "Layout" object of the api
needs to / could be bind independently from Pipeline

2/ One global Descriptor HEap is always bound and hold all the "updated descriptors"
   currently still updated by association with the DescriptorSet (this will change at some point)
   
3/ DescriptorSet is providing the binding from a bunch of descriptors on resources to the shader pipeline slots
  right now a single DescriptorSet per pipeline (this is changing next)
