### PR TITLE
Removing unecessary camera in allocateDrawcallObject call on Drawable…

### DIFF
--- a/src/graphics/drawables/GizmoDrawable.cpp
+++ b/src/graphics/drawables/GizmoDrawable.cpp
@@ -164,7 +164,6 @@ namespace graphics
    void GizmoDrawableFactory::allocateDrawcallObject(
         const graphics::DevicePointer& device,
         const graphics::ScenePointer& scene,
-        const graphics::CameraPointer& camera,
         graphics::NodeGizmo& gizmo)
     {
         auto pgizmo = &gizmo;
@@ -191,7 +190,6 @@ namespace graphics
    void GizmoDrawableFactory::allocateDrawcallObject(
         const graphics::DevicePointer& device,
         const graphics::ScenePointer& scene,
-        const graphics::CameraPointer& camera,
         graphics::ItemGizmo& gizmo)
    {
        // Create DescriptorSet #1, #0 is ViewPassDS

--- a/src/graphics/drawables/GizmoDrawable.h
+++ b/src/graphics/drawables/GizmoDrawable.h
@@ -81,12 +81,10 @@ namespace graphics {
         void allocateDrawcallObject(
             const graphics::DevicePointer& device,
             const graphics::ScenePointer& scene,
-            const graphics::CameraPointer& camera,
             graphics::NodeGizmo& gizmo);
         void allocateDrawcallObject(
             const graphics::DevicePointer& device,
             const graphics::ScenePointer& scene,
-            const graphics::CameraPointer& camera,
             graphics::ItemGizmo& gizmo);
 
         // Read / write shared uniforms

--- a/src/graphics/drawables/ModelDrawable.cpp
+++ b/src/graphics/drawables/ModelDrawable.cpp
@@ -579,7 +579,6 @@ namespace graphics
    void ModelDrawableFactory::allocateDrawcallObject(
         const graphics::DevicePointer& device,
         const graphics::ScenePointer& scene,
-        const graphics::CameraPointer& camera,
         graphics::ModelDrawable& model)
     {
        // It s time to create a descriptorSet that matches the expected pipeline descriptor set

--- a/src/graphics/drawables/ModelDrawable.h
+++ b/src/graphics/drawables/ModelDrawable.h
@@ -72,7 +72,6 @@ namespace graphics {
         void allocateDrawcallObject(
             const graphics::DevicePointer& device,
             const graphics::ScenePointer& scene,
-            const graphics::CameraPointer& camera,
             graphics::ModelDrawable& model);
 
         

--- a/src/graphics/drawables/ModelDrawableInspector.cpp
+++ b/src/graphics/drawables/ModelDrawableInspector.cpp
@@ -440,7 +440,6 @@ namespace graphics
     void ModelDrawableInspectorFactory::allocateDrawcallObject(
         const graphics::DevicePointer& device,
         const graphics::ScenePointer& scene,
-        const graphics::CameraPointer& camera,
         graphics::ModelDrawableInspector& model)
     {
         {

--- a/src/graphics/drawables/ModelDrawableInspector.h
+++ b/src/graphics/drawables/ModelDrawableInspector.h
@@ -175,7 +175,6 @@ namespace graphics {
         void allocateDrawcallObject(
             const graphics::DevicePointer& device,
             const graphics::ScenePointer& scene,
-            const graphics::CameraPointer& camera,
             graphics::ModelDrawableInspector& model);
 
         

--- a/src/graphics/drawables/PointcloudDrawable.cpp
+++ b/src/graphics/drawables/PointcloudDrawable.cpp
@@ -177,7 +177,6 @@ namespace graphics
     void PointCloudDrawableFactory::allocateDrawcallObject(
         const graphics::DevicePointer& device,
         const graphics::ScenePointer& scene,
-        const graphics::CameraPointer& camera,
         graphics::PointCloudDrawable& pointcloud)
     {
         graphics::DescriptorSetInit descriptorSetInit{

--- a/src/graphics/drawables/PointcloudDrawable.h
+++ b/src/graphics/drawables/PointcloudDrawable.h
@@ -88,8 +88,7 @@ namespace graphics {
         graphics::PointCloudDrawable* createPointCloudDrawable(const graphics::DevicePointer& device, const document::PointCloudPointer& pointcloud);
 
         // Create Drawcall object drawing the PointCloudDrawable in the rendering context
-        void allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::ScenePointer& scene, const graphics::CameraPointer& camera,
-               graphics::PointCloudDrawable& pointcloudDrawable);
+        void allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::ScenePointer& scene, graphics::PointCloudDrawable& pointcloudDrawable);
     
         // Read / write shared uniforms
         const PointCloudDrawableUniforms& getUniforms() const { return (*_sharedUniforms); }

--- a/src/graphics/drawables/PrimitiveDrawable.cpp
+++ b/src/graphics/drawables/PrimitiveDrawable.cpp
@@ -113,7 +113,6 @@ namespace graphics
    void PrimitiveDrawableFactory::allocateDrawcallObject(
         const graphics::DevicePointer& device,
         const graphics::ScenePointer& scene,
-        const graphics::CameraPointer& camera,
         graphics::PrimitiveDrawable& prim)
     {
         auto prim_ = &prim;

--- a/src/graphics/drawables/PrimitiveDrawable.h
+++ b/src/graphics/drawables/PrimitiveDrawable.h
@@ -65,7 +65,6 @@ namespace graphics {
         void allocateDrawcallObject(
             const graphics::DevicePointer& device,
             const graphics::ScenePointer& scene,
-            const graphics::CameraPointer& camera,
             graphics::PrimitiveDrawable& primitive);
 
         // Read / write shared uniforms

--- a/src/graphics/drawables/TriangleSoupDrawable.cpp
+++ b/src/graphics/drawables/TriangleSoupDrawable.cpp
@@ -188,7 +188,6 @@ namespace graphics
     void TriangleSoupDrawableFactory::allocateDrawcallObject(
         const graphics::DevicePointer& device,
         const graphics::ScenePointer& scene,
-        const graphics::CameraPointer& camera,
         graphics::TriangleSoupDrawable& triangleSoup)
     {
         // It s time to create a descriptorSet that matches the expected pipeline descriptor set

--- a/src/graphics/drawables/TriangleSoupDrawable.h
+++ b/src/graphics/drawables/TriangleSoupDrawable.h
@@ -66,8 +66,7 @@ namespace graphics {
         graphics::TriangleSoupDrawable* createTriangleSoupDrawable(const graphics::DevicePointer& device, const document::TriangleSoupPointer& pointcloud);
 
         // Create Drawcall object drawing the TriangleSoupDrawable in the rendering context
-        void allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::ScenePointer& scene, const graphics::CameraPointer& camera,
-            graphics::TriangleSoupDrawable& pointcloudDrawable);
+        void allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::ScenePointer& scene, graphics::TriangleSoupDrawable& pointcloudDrawable);
 
         // Read / write shared uniforms
         const TriangleSoupDrawableUniforms& getUniforms() const { return (*_sharedUniforms); }

--- a/src/graphics/render/Viewport.cpp
+++ b/src/graphics/render/Viewport.cpp
@@ -149,10 +149,8 @@ void Viewport::_renderCallback(RenderArgs& args) {
 
 void Viewport::renderScene(RenderArgs& args) {
 
-    args.batch->bindRootDescriptorLayout(graphics::PipelineType::GRAPHICS, _viewPassRootLayout);
-    args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, _viewPassDescriptorSet);
-
     args.viewPassDescriptorSet = _viewPassDescriptorSet;
+
     for (int i = 1; i < _scene->getItems().size(); i++) {
         auto& item = _scene->getItems()[i];
         if (item.isValid() && item.isVisible()) {

--- a/test/pico_04/pico_four.cpp
+++ b/test/pico_04/pico_four.cpp
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
 
     // a drawable from the pointcloud
     graphics::PointCloudDrawable* pointCloudDrawable(pointCloudDrawableFactory->createPointCloudDrawable(gpuDevice, pointCloud));
-    pointCloudDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, *pointCloudDrawable);
+    pointCloudDrawableFactory->allocateDrawcallObject(gpuDevice, scene, *pointCloudDrawable);
     auto pcdrawable = scene->createDrawable(*pointCloudDrawable);
 
     // A triangel soup drawable factory
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
 
     // a drawable from the trianglesoup
     graphics::TriangleSoupDrawable* triangleSoupDrawable(triangleSoupDrawableFactory->createTriangleSoupDrawable(gpuDevice, triangleSoup));
-    triangleSoupDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, *triangleSoupDrawable);
+    triangleSoupDrawableFactory->allocateDrawcallObject(gpuDevice, scene, *triangleSoupDrawable);
     auto tsdrawable = scene->createDrawable(*triangleSoupDrawable);
 
     // A gizmo drawable factory
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
 
     // a Primitive
     auto p_drawable = scene->createDrawable(*primitiveDrawableFactory->createPrimitive(gpuDevice));
-    primitiveDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, p_drawable.as<graphics::PrimitiveDrawable>());
+    primitiveDrawableFactory->allocateDrawcallObject(gpuDevice, scene, p_drawable.as<graphics::PrimitiveDrawable>());
     p_drawable.as<graphics::PrimitiveDrawable>()._size = {1.0, 2.0, 0.7 };
 
     std::vector<graphics::NodeID> prim_nodes;
@@ -202,11 +202,11 @@ int main(int argc, char *argv[])
 
     // a gizmo drawable to draw the transforms
     auto gzdrawable = scene->createDrawable(*gizmoDrawableFactory->createNodeGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable.as<graphics::NodeGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable.as<graphics::NodeGizmo>());
     gzdrawable.as<graphics::NodeGizmo>().nodes.resize(6);
 
     auto gzdrawable_item = scene->createDrawable(*gizmoDrawableFactory->createItemGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_item.as<graphics::ItemGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_item.as<graphics::ItemGizmo>());
     gzdrawable_item.as<graphics::ItemGizmo>().items.resize(100);
 
 

--- a/test/pico_eye/pico_eye.cpp
+++ b/test/pico_eye/pico_eye.cpp
@@ -75,7 +75,7 @@ AppState state;
 
 
 
-graphics::NodeIDs generateModel(document::ModelPointer lmodel, graphics::DevicePointer& gpuDevice, graphics::ScenePointer& scene, graphics::CameraPointer& camera, graphics::Node& root) {
+graphics::NodeIDs generateModel(document::ModelPointer lmodel, graphics::DevicePointer& gpuDevice, graphics::ScenePointer& scene, graphics::Node& root) {
 
     if (!state._modelDrawableFactory) {
         state._modelDrawableFactory = std::make_shared<graphics::ModelDrawableFactory>();
@@ -84,7 +84,7 @@ graphics::NodeIDs generateModel(document::ModelPointer lmodel, graphics::DeviceP
     }
 
     auto modelDrawablePtr = state._modelDrawableFactory->createModel(gpuDevice, lmodel);
-    state._modelDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, *modelDrawablePtr);
+    state._modelDrawableFactory->allocateDrawcallObject(gpuDevice, scene, *modelDrawablePtr);
 
     graphics::ItemIDs modelItemIDs;
 
@@ -179,14 +179,14 @@ int main(int argc, char *argv[])
 
     // a gizmo drawable to draw the transforms
     auto gzdrawable_node = scene->createDrawable(*gizmoDrawableFactory->createNodeGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_node.as<graphics::NodeGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_node.as<graphics::NodeGizmo>());
     gzdrawable_node.as<graphics::NodeGizmo>().nodes.resize(scene->_nodes._nodes_buffer->getNumElements());
     auto gzitem_node = scene->createItem(graphics::Node::null, gzdrawable_node);
     gzitem_node.setVisible(false);
 
 
     auto gzdrawable_item = scene->createDrawable(*gizmoDrawableFactory->createItemGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_item.as<graphics::ItemGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_item.as<graphics::ItemGizmo>());
     gzdrawable_item.as<graphics::ItemGizmo>().items.resize(scene->_items._items_buffer->getNumElements());
     auto gzitem_item = scene->createItem(graphics::Node::null, gzdrawable_item);
     gzitem_item.setVisible(false);
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
     // Some nodes to layout the scene and animate objects
     state._modelRootNode = scene->createNode(core::mat4x3(), -1);
 
-    auto modelItemIDs = generateModel(loadModel(), gpuDevice, scene, camera, state._modelRootNode);
+    auto modelItemIDs = generateModel(loadModel(), gpuDevice, scene, state._modelRootNode);
     if (modelItemIDs.size()) {
          state._modelItemID = modelItemIDs[0];
     }
@@ -367,7 +367,7 @@ int main(int argc, char *argv[])
 
             document::ModelPointer lmodel = document::model::Model::createFromGLTF(e.fileUrls[0]);
             if (lmodel) {
-                auto modelItemIDs = generateModel(lmodel, gpuDevice, scene, camera, state._modelRootNode);
+                auto modelItemIDs = generateModel(lmodel, gpuDevice, scene, state._modelRootNode);
             }
         }
         return;

--- a/test/pico_model/pico_model.cpp
+++ b/test/pico_model/pico_model.cpp
@@ -127,7 +127,7 @@ graphics::NodeIDs generateModel(graphics::DevicePointer& gpuDevice, graphics::Sc
     }
 
     auto modelDrawablePtr = state._modelDrawableFactory->createModel(gpuDevice, lmodel);
-    state._modelDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, *modelDrawablePtr);
+    state._modelDrawableFactory->allocateDrawcallObject(gpuDevice, scene, *modelDrawablePtr);
 
     auto modelDrawable = scene->createDrawable(*modelDrawablePtr);
 
@@ -141,7 +141,7 @@ graphics::NodeIDs generateModel(graphics::DevicePointer& gpuDevice, graphics::Sc
             state.params->setFilterKernelTechnique(graphics::ModelDrawableInspectorUniforms::FKT_IMAGE_SPACE);
         }
         auto modelDrawableInspectorPtr = state._modelDrawableInspectorFactory->createModel(gpuDevice, lmodel, modelDrawablePtr);
-        state._modelDrawableInspectorFactory->allocateDrawcallObject(gpuDevice, scene, camera, *modelDrawableInspectorPtr);
+        state._modelDrawableInspectorFactory->allocateDrawcallObject(gpuDevice, scene, *modelDrawableInspectorPtr);
 
         auto modelDrawableInspector = scene->createDrawable(*modelDrawableInspectorPtr);
 
@@ -197,14 +197,14 @@ int main(int argc, char *argv[])
 
     // a gizmo drawable to draw the transforms
     auto gzdrawable_node = scene->createDrawable(*gizmoDrawableFactory->createNodeGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_node.as<graphics::NodeGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_node.as<graphics::NodeGizmo>());
     gzdrawable_node.as<graphics::NodeGizmo>().nodes.resize(scene->_nodes._nodes_buffer->getNumElements());
     auto gzitem_node = scene->createItem(graphics::Node::null, gzdrawable_node);
     gzitem_node.setVisible(false);
 
 
     auto gzdrawable_item = scene->createDrawable(*gizmoDrawableFactory->createItemGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_item.as<graphics::ItemGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_item.as<graphics::ItemGizmo>());
     gzdrawable_item.as<graphics::ItemGizmo>().items.resize(scene->_items._items_buffer->getNumElements());
     auto gzitem_item = scene->createItem(graphics::Node::null, gzdrawable_item);
     gzitem_item.setVisible(false);

--- a/test/pico_ocean/pico_ocean.cpp
+++ b/test/pico_ocean/pico_ocean.cpp
@@ -113,14 +113,14 @@ int main(int argc, char *argv[])
 
     // a gizmo drawable to draw the transforms
     auto gzdrawable_node = scene->createDrawable(*gizmoDrawableFactory->createNodeGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_node.as<graphics::NodeGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_node.as<graphics::NodeGizmo>());
     gzdrawable_node.as<graphics::NodeGizmo>().nodes.resize(ocean_resolution * ocean_resolution);
     auto gzitem_node = scene->createItem(graphics::Node::null, gzdrawable_node);
     gzitem_node.setVisible(false);
 
 
     auto gzdrawable_item = scene->createDrawable(*gizmoDrawableFactory->createItemGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_item.as<graphics::ItemGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_item.as<graphics::ItemGizmo>());
     gzdrawable_item.as<graphics::ItemGizmo>().items.resize(100);
     auto gzitem_item = scene->createItem(graphics::Node::null, gzdrawable_item);
     gzitem_item.setVisible(false);

--- a/test/pico_terrain/pico_terrain.cpp
+++ b/test/pico_terrain/pico_terrain.cpp
@@ -148,14 +148,14 @@ int main(int argc, char *argv[])
 
     // a gizmo drawable to draw the transforms
     auto gzdrawable_node = scene->createDrawable(*gizmoDrawableFactory->createNodeGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_node.as<graphics::NodeGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_node.as<graphics::NodeGizmo>());
     gzdrawable_node.as<graphics::NodeGizmo>().nodes.resize(scene->_nodes._nodes_buffer->getNumElements());
     auto gzitem_node = scene->createItem(graphics::Node::null, gzdrawable_node);
     gzitem_node.setVisible(false);
 
 
     auto gzdrawable_item = scene->createDrawable(*gizmoDrawableFactory->createItemGizmo(gpuDevice));
-    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, camera, gzdrawable_item.as<graphics::ItemGizmo>());
+    gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_item.as<graphics::ItemGizmo>());
     gzdrawable_item.as<graphics::ItemGizmo>().items.resize(scene->_items._items_buffer->getNumElements());
     auto gzitem_item = scene->createItem(graphics::Node::null, gzdrawable_item);
     gzitem_item.setVisible(false);


### PR DESCRIPTION
… factories, since now it is provided by the viewPassDescriptor