### PR TITLE
better empty rootDescriptorLayout

### DIFF
--- a/src/graphics/d3d12/D3D12Backend.cpp
+++ b/src/graphics/d3d12/D3D12Backend.cpp
@@ -383,6 +383,9 @@ D3D12Backend::D3D12Backend() {
         1000
     };
     _descriptorHeap = this->createDescriptorHeap(descriptorHeapInit);
+
+    // Allocate a default empty pipeline layout
+    _emptyRootDescriptorLayout = this->createRootDescriptorLayout( {} );
 }
 
 D3D12Backend::~D3D12Backend() {

--- a/src/graphics/d3d12/D3D12Backend.h
+++ b/src/graphics/d3d12/D3D12Backend.h
@@ -99,9 +99,6 @@ namespace graphics {
         uint64_t _frameFenceValues[D3D12Backend::CHAIN_NUM_FRAMES] = {};
         HANDLE _fenceEvent;
 
-        // Memory management
-        DescriptorHeapPointer _descriptorHeap;
-
         SwapchainPointer createSwapchain(const SwapchainInit& init) override;
         void resizeSwapchain(const SwapchainPointer& swapchain, uint32_t width, uint32_t height) override;
 
@@ -126,12 +123,18 @@ namespace graphics {
 
         void updateDescriptorSet(DescriptorSetPointer& descriptorSet, DescriptorObjects& objects) override;
         DescriptorHeapPointer createDescriptorHeap(const DescriptorHeapInit& init) override;
-        DescriptorHeapPointer getDescriptorHeap() override;
 
         void executeBatch(const BatchPointer& batch) override;
         void presentSwapchain(const SwapchainPointer& swapchain) override;
 
         void flush() override;
+
+        // Default empty pipeline layout
+        RootDescriptorLayoutPointer _emptyRootDescriptorLayout;
+
+        // Global Descriptor Heap
+        DescriptorHeapPointer getDescriptorHeap() override;
+        DescriptorHeapPointer _descriptorHeap;
 
         // Separate shader and pipeline state compilation as functions in order
         // to be able to live edit the shaders

--- a/src/graphics/d3d12/D3D12Backend_Batch.cpp
+++ b/src/graphics/d3d12/D3D12Backend_Batch.cpp
@@ -268,16 +268,11 @@ void D3D12BatchBackend::bindPipeline(const PipelineStatePointer& pipeline) {
     auto dxPso = dpso->_pipelineState;
     _commandList->SetPipelineState(dxPso.Get());
 
-    auto rdl = pipeline->getRootDescriptorLayout();
-    if (rdl)
-        bindRootDescriptorLayout(dpso->getType(), rdl);
-
-    auto dxRS = dpso->_rootSignature;
+    bindRootDescriptorLayout(dpso->getType(), dpso->getRootDescriptorLayout());
+ 
     if (dpso->getType() == PipelineType::GRAPHICS) {
-     //   _commandList->SetGraphicsRootSignature(dxRS.Get());
         _commandList->IASetPrimitiveTopology(dpso->_primitive_topology);
     } else if (dpso->getType() == PipelineType::COMPUTE) {
-     //   _commandList->SetComputeRootSignature(dxRS.Get());
     }
 }
 

--- a/src/graphics/d3d12/D3D12Backend_Descriptor.cpp
+++ b/src/graphics/d3d12/D3D12Backend_Descriptor.cpp
@@ -84,9 +84,20 @@ D3D12_SHADER_VISIBILITY EvalShaderVisibility(ShaderStage _shaderStage) {
  }
 
 RootDescriptorLayoutPointer D3D12Backend::createRootDescriptorLayout(const RootDescriptorLayoutInit& init) {
-    if (init._pushLayout.empty() && init._samplerLayout.empty() && init._setLayouts.empty()) {
+ /*   if (init._pushLayout.empty() && init._samplerLayout.empty() && init._setLayouts.empty()) {
+        D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+        rootSignatureDesc.NumParameters = 0;
+        rootSignatureDesc.pParameters = nullptr;
+        rootSignatureDesc.NumStaticSamplers = 0;
+        rootSignatureDesc.pStaticSamplers = nullptr;
+        rootSignatureDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+
+        ComPtr<ID3DBlob> signature;
+        ComPtr<ID3DBlob> error;
+        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+        ThrowIfFailed(_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&rootSignature)));
         return nullptr;
-    }
+    }*/
 
     auto descriptorLayout = new D3D12RootDescriptorLayoutBackend();
 

--- a/src/graphics/d3d12/D3D12Backend_Descriptor.cpp
+++ b/src/graphics/d3d12/D3D12Backend_Descriptor.cpp
@@ -84,21 +84,6 @@ D3D12_SHADER_VISIBILITY EvalShaderVisibility(ShaderStage _shaderStage) {
  }
 
 RootDescriptorLayoutPointer D3D12Backend::createRootDescriptorLayout(const RootDescriptorLayoutInit& init) {
- /*   if (init._pushLayout.empty() && init._samplerLayout.empty() && init._setLayouts.empty()) {
-        D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-        rootSignatureDesc.NumParameters = 0;
-        rootSignatureDesc.pParameters = nullptr;
-        rootSignatureDesc.NumStaticSamplers = 0;
-        rootSignatureDesc.pStaticSamplers = nullptr;
-        rootSignatureDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
-
-        ComPtr<ID3DBlob> signature;
-        ComPtr<ID3DBlob> error;
-        ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-        ThrowIfFailed(_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&rootSignature)));
-        return nullptr;
-    }*/
-
     auto descriptorLayout = new D3D12RootDescriptorLayoutBackend();
 
     D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData;

--- a/src/graphics/d3d12/D3D12Backend_Pipeline.cpp
+++ b/src/graphics/d3d12/D3D12Backend_Pipeline.cpp
@@ -54,7 +54,7 @@ bool D3D12Backend::realizePipelineState(PipelineState* pipeline) {
         ComPtr<ID3D12RootSignature> rootSignature;
         ComPtr<ID3D12PipelineState> pipelineState;
 
-        // Grab the root signature from the associated pipaline layout.
+        // Grab the root signature from the associated pipeline layout.
         if (pso->_rootSignature) {
             rootSignature = pso->_rootSignature;
         } else {
@@ -139,26 +139,13 @@ bool D3D12Backend::realizePipelineState(PipelineState* pipeline) {
         ComPtr<ID3D12RootSignature> rootSignature;
         ComPtr<ID3D12PipelineState> pipelineState;
 
-        // Create an empty root signature if none provided.
+        // Grab the root signature from the associated pipeline layout.
         if (pso->_rootSignature) {
             rootSignature = pso->_rootSignature;
         }
         else if (init.rootDescriptorLayout) {
             auto dxDescLayout = static_cast<D3D12RootDescriptorLayoutBackend*> (init.rootDescriptorLayout.get());
             rootSignature = dxDescLayout->_rootSignature;
-        }
-        else {
-            D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-            rootSignatureDesc.NumParameters = 0;
-            rootSignatureDesc.pParameters = nullptr;
-            rootSignatureDesc.NumStaticSamplers = 0;
-            rootSignatureDesc.pStaticSamplers = nullptr;
-            rootSignatureDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
-
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-            ThrowIfFailed(_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&rootSignature)));
         }
 
         D3D12_COMPUTE_PIPELINE_STATE_DESC psoDesc = {};
@@ -192,7 +179,7 @@ PipelineStatePointer D3D12Backend::createGraphicsPipelineState(const GraphicsPip
     pso->_type = PipelineType::GRAPHICS;
     pso->_graphics = init;
     pso->_program = init.program;
-    pso->_rootDescriptorLayout = ( init.rootDescriptorLayout ? init.rootDescriptorLayout : _emptyRootDescriptorLayout); // assign empty pipeline layout
+    pso->_rootDescriptorLayout = ( init.rootDescriptorLayout ? init.rootDescriptorLayout : _emptyRootDescriptorLayout); // assign empty pipeline layout if none specified
 
     if (realizePipelineState(pso.get())) {
 
@@ -215,7 +202,7 @@ PipelineStatePointer D3D12Backend::createComputePipelineState(const ComputePipel
     pso->_type = PipelineType::COMPUTE;
     pso->_compute = init;
     pso->_program = init.program;
-    pso->_rootDescriptorLayout = (init.rootDescriptorLayout ? init.rootDescriptorLayout : _emptyRootDescriptorLayout); // assign empty pipeline layout
+    pso->_rootDescriptorLayout = (init.rootDescriptorLayout ? init.rootDescriptorLayout : _emptyRootDescriptorLayout); // assign empty pipeline layout if none specified
 
 
     if (realizePipelineState(pso.get())) {

--- a/src/graphics/d3d12/D3D12Backend_Pipeline.cpp
+++ b/src/graphics/d3d12/D3D12Backend_Pipeline.cpp
@@ -54,25 +54,13 @@ bool D3D12Backend::realizePipelineState(PipelineState* pipeline) {
         ComPtr<ID3D12RootSignature> rootSignature;
         ComPtr<ID3D12PipelineState> pipelineState;
 
-        // Create an empty root signature if none provided.
+        // Grab the root signature from the associated pipaline layout.
         if (pso->_rootSignature) {
             rootSignature = pso->_rootSignature;
-        } else if (init.rootDescriptorLayout) {
-            auto dxDescLayout = static_cast<D3D12RootDescriptorLayoutBackend*> (init.rootDescriptorLayout.get());
+        } else {
+            picoAssert((bool) pso->_rootDescriptorLayout);
+            auto dxDescLayout = static_cast<D3D12RootDescriptorLayoutBackend*> (pso->_rootDescriptorLayout.get());
             rootSignature = dxDescLayout->_rootSignature;
-        }
-        else {
-            D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc;
-            rootSignatureDesc.NumParameters = 0;
-            rootSignatureDesc.pParameters = nullptr;
-            rootSignatureDesc.NumStaticSamplers = 0;
-            rootSignatureDesc.pStaticSamplers = nullptr;
-            rootSignatureDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
-
-            ComPtr<ID3DBlob> signature;
-            ComPtr<ID3DBlob> error;
-            ThrowIfFailed(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
-            ThrowIfFailed(_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&rootSignature)));
         }
 
         {
@@ -204,7 +192,7 @@ PipelineStatePointer D3D12Backend::createGraphicsPipelineState(const GraphicsPip
     pso->_type = PipelineType::GRAPHICS;
     pso->_graphics = init;
     pso->_program = init.program;
-    pso->_rootDescriptorLayout = init.rootDescriptorLayout;
+    pso->_rootDescriptorLayout = ( init.rootDescriptorLayout ? init.rootDescriptorLayout : _emptyRootDescriptorLayout); // assign empty pipeline layout
 
     if (realizePipelineState(pso.get())) {
 
@@ -227,7 +215,7 @@ PipelineStatePointer D3D12Backend::createComputePipelineState(const ComputePipel
     pso->_type = PipelineType::COMPUTE;
     pso->_compute = init;
     pso->_program = init.program;
-    pso->_rootDescriptorLayout = init.rootDescriptorLayout;
+    pso->_rootDescriptorLayout = (init.rootDescriptorLayout ? init.rootDescriptorLayout : _emptyRootDescriptorLayout); // assign empty pipeline layout
 
 
     if (realizePipelineState(pso.get())) {

--- a/src/graphics/gpu/Descriptor.h
+++ b/src/graphics/gpu/Descriptor.h
@@ -49,8 +49,9 @@ namespace graphics {
 
 
     // Root Descriptor Layout
-    // A DescriptorLayout for push constants
+    // 1 DescriptorLayout for push constants
     // N DescriptorSetLayouts for resources
+    // 1 DescriptorSetLayout for samplers
     struct VISUALIZATION_API RootDescriptorLayoutInit {
         DescriptorSetLayout  _pushLayout;
         DescriptorSetLayouts _setLayouts;

--- a/test/pico_02/CMakeLists.txt
+++ b/test/pico_02/CMakeLists.txt
@@ -7,3 +7,5 @@ target_compile_features(pico_02 PRIVATE cxx_std_17)
 target_include_directories(pico_02 PRIVATE ../../src)
 
 target_link_libraries(pico_02 graphics uix)
+
+set_property(TARGET pico_02 PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test/pico_02")

--- a/test/pico_03/CMakeLists.txt
+++ b/test/pico_03/CMakeLists.txt
@@ -9,3 +9,5 @@ target_include_directories(pico_03 PRIVATE ../../src)
 target_link_libraries(pico_03 core document graphics uix)
 
 add_dependencies(pico_03 core document graphics uix)
+
+set_property(TARGET pico_03 PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test/pico_03")

--- a/test/pico_04/CMakeLists.txt
+++ b/test/pico_04/CMakeLists.txt
@@ -7,3 +7,6 @@ target_compile_features(pico_04 PRIVATE cxx_std_17)
 target_include_directories(pico_04 PRIVATE ../../src)
 
 target_link_libraries(pico_04 graphics uix)
+
+
+set_property(TARGET pico_04 PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test/pico_04")

--- a/test/pico_eye/CMakeLists.txt
+++ b/test/pico_eye/CMakeLists.txt
@@ -7,3 +7,5 @@ target_compile_features(pico_eye PRIVATE cxx_std_17)
 target_include_directories(pico_eye PRIVATE ../../src)
 
 target_link_libraries(pico_eye graphics uix)
+
+set_property(TARGET pico_eye PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test/pico_eye")

--- a/test/pico_interop-gdi/CMakeLists.txt
+++ b/test/pico_interop-gdi/CMakeLists.txt
@@ -7,3 +7,5 @@ target_compile_features(pico_interop-gdi PRIVATE cxx_std_17)
 target_include_directories(pico_interop-gdi PRIVATE ../../src)
 
 target_link_libraries(pico_interop-gdi graphics uix)
+
+set_property(TARGET pico_interop-gdi PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test/pico_interop-gdi")

--- a/test/pico_model/CMakeLists.txt
+++ b/test/pico_model/CMakeLists.txt
@@ -7,3 +7,5 @@ target_compile_features(pico_model PRIVATE cxx_std_17)
 target_include_directories(pico_model PRIVATE ../../src)
 
 target_link_libraries(pico_model graphics uix)
+
+set_property(TARGET pico_model PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test/pico_model")

--- a/test/pico_ocean/CMakeLists.txt
+++ b/test/pico_ocean/CMakeLists.txt
@@ -7,3 +7,5 @@ target_compile_features(pico_ocean PRIVATE cxx_std_17)
 target_include_directories(pico_ocean PRIVATE ../../src)
 
 target_link_libraries(pico_ocean graphics uix)
+
+set_property(TARGET pico_ocean PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test/pico_ocean")

--- a/test/pico_terrain/CMakeLists.txt
+++ b/test/pico_terrain/CMakeLists.txt
@@ -7,3 +7,5 @@ target_compile_features(pico_terrain PRIVATE cxx_std_17)
 target_include_directories(pico_terrain PRIVATE ../../src)
 
 target_link_libraries(pico_terrain graphics uix)
+
+set_property(TARGET pico_terrain PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test/pico_terrain")


### PR DESCRIPTION
- make sure the projects are always configured with the correct debug working dir
- clean up the case for empty rootDescriptorLayout