### PR TITLE
Frist step of putting introducing the camera array in the scene

### DIFF
--- a/src/core/stl/IndexTable.h
+++ b/src/core/stl/IndexTable.h
@@ -59,22 +59,24 @@ namespace core {
             return true;
         }
 
-        Index allocate() {
+        auto allocate() {
+            struct result { Index index; bool recycle; };
             Index new_index;
             if (_invalid_elements.size()) {
                 new_index = _invalid_elements.back();
                 _invalid_elements.pop_back();
+                return result{ new_index, true};
             } else {
                 new_index = _num_allocated_elements;
                 _num_allocated_elements++;
+                return result{ new_index, false};
             }
-            return new_index;
         }
 
         Indices allocate(Index num_elements) {
             Indices allocated(num_elements, INVALID_INDEX);
             for (auto& index : allocated) {
-                index = allocate();
+                index = allocate().index;
             }
             return std::move(allocated);
         }

--- a/src/graphics/drawables/DashboardDrawable.h
+++ b/src/graphics/drawables/DashboardDrawable.h
@@ -37,8 +37,6 @@
 namespace graphics {
     class Device;
     using DevicePointer = std::shared_ptr<Device>;
-    class Camera;
-    using CameraPointer = std::shared_ptr<Camera>;
     class Buffer;
     using BufferPointer = std::shared_ptr<Buffer>;
     class PipelineState;

--- a/src/graphics/drawables/Dashboard_vert.hlsl
+++ b/src/graphics/drawables/Dashboard_vert.hlsl
@@ -58,6 +58,8 @@ VertexShaderOutput main(uint ivid : SV_VertexID)
         position.z -= 0.1;   
     }
     
+    Projection _projection = cam_projection();
+    
     float3 eyePosition = position;
     float4 clipPos = clipFromEyeSpace(_projection, eyePosition);
 

--- a/src/graphics/drawables/GizmoDrawable.cpp
+++ b/src/graphics/drawables/GizmoDrawable.cpp
@@ -171,7 +171,17 @@ namespace graphics
         return gizmoDrawable;
     }
 
-   void GizmoDrawableFactory::allocateDrawcallObject(
+    graphics::CameraGizmo* GizmoDrawableFactory::createCameraGizmo(const graphics::DevicePointer& device) {
+
+        auto gizmoDrawable = new CameraGizmo();
+
+        // Create the triangle soup drawable using the shared uniforms of the factory
+        gizmoDrawable->_uniforms = _sharedUniforms;
+
+        return gizmoDrawable;
+    }
+
+    void GizmoDrawableFactory::allocateDrawcallObject(
         const graphics::DevicePointer& device,
         const graphics::ScenePointer& scene,
         graphics::NodeGizmo& gizmo)
@@ -222,6 +232,47 @@ namespace graphics
        // And now a render callback where we describe the rendering sequence
        graphics::DrawObjectCallback drawCallback = [pgizmo, descriptorSet, pipeline](const NodeID node, RenderArgs& args) {
            
+           args.batch->bindPipeline(pipeline);
+           args.batch->setViewport(args.camera->getViewportRect());
+           args.batch->setScissor(args.camera->getViewportRect());
+
+           args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, args.viewPassDescriptorSet);
+           args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, descriptorSet);
+
+           auto flags = pgizmo->getUniforms()->buildFlags();
+           GizmoObjectData odata{ node, flags, 0, 0 };
+           args.batch->bindPushUniform(graphics::PipelineType::GRAPHICS, 0, sizeof(GizmoObjectData), (const uint8_t*)&odata);
+
+           args.batch->draw(pgizmo->items.size() * 2 * ((flags & GizmoDrawableUniforms::SHOW_LOCAL_BOUND_BIT) * 12 + (flags & GizmoDrawableUniforms::SHOW_WORLD_BOUND_BIT) * 12), 0);
+       };
+       gizmo._drawcall = drawCallback;
+   }
+
+   void GizmoDrawableFactory::allocateDrawcallObject(
+       const graphics::DevicePointer& device,
+       const graphics::ScenePointer& scene,
+       graphics::CameraGizmo& gizmo)
+   {
+       // Create DescriptorSet #1, #0 is ViewPassDS
+       graphics::DescriptorSetInit descriptorSetInit{
+           _itemPipeline->getRootDescriptorLayout(),
+            1
+       };
+       auto descriptorSet = device->createDescriptorSet(descriptorSetInit);
+
+       graphics::DescriptorObjects descriptorObjects = { {
+            { graphics::DescriptorType::RESOURCE_BUFFER, scene->_drawables._drawables_buffer },
+            { graphics::DescriptorType::RESOURCE_BUFFER, scene->_items._items_buffer },
+
+       } };
+       device->updateDescriptorSet(descriptorSet, descriptorObjects);
+
+       auto pgizmo = &gizmo;
+       auto pipeline = this->_itemPipeline;
+
+       // And now a render callback where we describe the rendering sequence
+       graphics::DrawObjectCallback drawCallback = [pgizmo, descriptorSet, pipeline](const NodeID node, RenderArgs& args) {
+
            args.batch->bindPipeline(pipeline);
            args.batch->setViewport(args.camera->getViewportRect());
            args.batch->setScissor(args.camera->getViewportRect());

--- a/src/graphics/drawables/GizmoDrawable.cpp
+++ b/src/graphics/drawables/GizmoDrawable.cpp
@@ -221,7 +221,7 @@ namespace graphics
 
        graphics::DescriptorObjects descriptorObjects = {{
             { graphics::DescriptorType::RESOURCE_BUFFER, scene->_drawables._drawables_buffer },
-            { graphics::DescriptorType::RESOURCE_BUFFER, scene->_items._items_buffer },
+            { graphics::DescriptorType::RESOURCE_BUFFER, scene->_items.getGPUBuffer()},
 
        }};
        device->updateDescriptorSet(descriptorSet, descriptorObjects);
@@ -262,7 +262,7 @@ namespace graphics
 
        graphics::DescriptorObjects descriptorObjects = { {
             { graphics::DescriptorType::RESOURCE_BUFFER, scene->_drawables._drawables_buffer },
-            { graphics::DescriptorType::RESOURCE_BUFFER, scene->_items._items_buffer },
+            { graphics::DescriptorType::RESOURCE_BUFFER, scene->_items.getGPUBuffer()},
 
        } };
        device->updateDescriptorSet(descriptorSet, descriptorObjects);

--- a/src/graphics/drawables/GizmoDrawable.h
+++ b/src/graphics/drawables/GizmoDrawable.h
@@ -47,6 +47,7 @@ namespace graphics {
 
     class NodeGizmo;
     class ItemGizmo;
+    class CameraGizmo;
 
     struct VISUALIZATION_API GizmoDrawableUniforms {
         int numNodes{ 0 };
@@ -76,6 +77,7 @@ namespace graphics {
         // Create GizmoDrawable for a given Gizmo document, building the gpu vertex buffer
         graphics::NodeGizmo* createNodeGizmo(const graphics::DevicePointer& device);
         graphics::ItemGizmo* createItemGizmo(const graphics::DevicePointer& device);
+        graphics::CameraGizmo* createCameraGizmo(const graphics::DevicePointer& device);
 
         // Create Drawcall object drawing the GizmoDrawable in the rendering context
         void allocateDrawcallObject(
@@ -86,6 +88,10 @@ namespace graphics {
             const graphics::DevicePointer& device,
             const graphics::ScenePointer& scene,
             graphics::ItemGizmo& gizmo);
+        void allocateDrawcallObject(
+            const graphics::DevicePointer& device,
+            const graphics::ScenePointer& scene,
+            graphics::CameraGizmo& gizmo);
 
         // Read / write shared uniforms
         const GizmoDrawableUniforms& getUniforms() const { return (*_sharedUniforms); }
@@ -95,6 +101,7 @@ namespace graphics {
         GizmoDrawableUniformsPointer _sharedUniforms;
         graphics::PipelineStatePointer _nodePipeline;
         graphics::PipelineStatePointer _itemPipeline;
+        graphics::PipelineStatePointer _cameraPipeline;
     };
     using GizmoDrawableFactoryPointer = std::shared_ptr< GizmoDrawableFactory>;
 
@@ -133,5 +140,21 @@ namespace graphics {
         DrawObjectCallback _drawcall;
     };
 
+    class VISUALIZATION_API CameraGizmo {
+    public:
+        std::vector<ItemID> items;
+
+        void swapUniforms(const GizmoDrawableUniformsPointer& uniforms) { _uniforms = uniforms; }
+        const GizmoDrawableUniformsPointer& getUniforms() const { return _uniforms; }
+
+        core::aabox3 getBound() const { return core::aabox3(); }
+        DrawObjectCallback getDrawcall() const { return _drawcall; }
+
+    protected:
+        friend class GizmoDrawableFactory;
+
+        GizmoDrawableUniformsPointer _uniforms;
+        DrawObjectCallback _drawcall;
+    };
 
 } // !namespace graphics

--- a/src/graphics/drawables/GizmoDrawable.h
+++ b/src/graphics/drawables/GizmoDrawable.h
@@ -38,8 +38,6 @@ namespace graphics {
     using DevicePointer = std::shared_ptr<Device>;
     class TransformTreeGPU;
     using TransformTreeGPUPointer = std::shared_ptr<TransformTreeGPU>;
-    class Camera;
-    using CameraPointer = std::shared_ptr<Camera>;
     class Buffer;
     using BufferPointer = std::shared_ptr<Buffer>;
     class PipelineState;

--- a/src/graphics/drawables/GizmoItem_vert.hlsl
+++ b/src/graphics/drawables/GizmoItem_vert.hlsl
@@ -59,8 +59,8 @@ VertexShaderOutput main(uint ivid : SV_VertexID)
         color = float3(float(lid < 4), float(lid >= 4 && lid < 8), float(lid >= 8));
     }
 
-    float3 eyePosition = eyeFromWorldSpace(_view, position);
-    float4 clipPos = clipFromEyeSpace(_projection, eyePosition);
+    float3 eyePosition = eyeFromWorldSpace(cam_view(), position);
+    float4 clipPos = clipFromEyeSpace(cam_projection(), eyePosition);
 
     OUT.Position = clipPos;
     OUT.Color = float4(color, 1.0f);

--- a/src/graphics/drawables/GizmoNode_vert.hlsl
+++ b/src/graphics/drawables/GizmoNode_vert.hlsl
@@ -54,8 +54,8 @@ VertexShaderOutput main(uint ivid : SV_VertexID)
     }
 
     position = worldFromObjectSpace(_model, position);
-    float3 eyePosition = eyeFromWorldSpace(_view, position);
-    float4 clipPos = clipFromEyeSpace(_projection, eyePosition);
+    float3 eyePosition = eyeFromWorldSpace(cam_view(), position);
+    float4 clipPos = clipFromEyeSpace(cam_projection(), eyePosition);
 
     OUT.Position = clipPos;
     OUT.Color = float4(color, 1.0f);

--- a/src/graphics/drawables/Heightmap_frag.hlsl
+++ b/src/graphics/drawables/Heightmap_frag.hlsl
@@ -97,7 +97,7 @@ float4 main(PixelShaderInput IN) : SV_Target
     float3 N = normalize(cross(ddy(IN.WPos), ddx(IN.WPos)));
 
 
-    float3 E2F = IN.WPos - _view.col_w();
+    float3 E2F = IN.WPos - cam_view().col_w();
     float E2Flen = length(E2F);
     float3 V = -normalize(E2F);
     float3 H = normalize(V + L);

--- a/src/graphics/drawables/Heightmap_vert.hlsl
+++ b/src/graphics/drawables/Heightmap_vert.hlsl
@@ -178,8 +178,8 @@ VertexShaderOutput main(uint ivid : SV_VertexID)
     Transform _model = node_getWorldTransform(_nodeID);
 
     position = worldFromObjectSpace(_model, position);
-    float3 eyePosition = eyeFromWorldSpace(_view, position);
-    float4 clipPos = clipFromEyeSpace(_projection, eyePosition);
+    float3 eyePosition = eyeFromWorldSpace(cam_view(), position);
+    float4 clipPos = clipFromEyeSpace(cam_projection(), eyePosition);
 
     OUT.Position = clipPos;
     OUT.WPos = position;

--- a/src/graphics/drawables/ModelDrawable.h
+++ b/src/graphics/drawables/ModelDrawable.h
@@ -36,8 +36,6 @@
 namespace graphics {
     class Device;
     using DevicePointer = std::shared_ptr<Device>;
-    class Camera;
-    using CameraPointer = std::shared_ptr<Camera>;
     class Buffer;
     using BufferPointer = std::shared_ptr<Buffer>;
     class PipelineState;

--- a/src/graphics/drawables/ModelInspectorPart_frag.hlsl
+++ b/src/graphics/drawables/ModelInspectorPart_frag.hlsl
@@ -181,9 +181,9 @@ float4 main(PixelShaderInput IN) : SV_Target{
 
     float4 mapN = (mapNor *2.0 - 1.0);
     float3 surfNormal = normalize(IN.Normal);
-    float3 normal = computeNormal(surfNormal, mapN, IN.EyePos.xyz, IN.Texcoord.xy);
+    float3 normal = computeNormal(surfNormal, mapN.xyz, IN.EyePos.xyz, IN.Texcoord.xy);
 
-    normal = worldFromEyeSpaceDir(_view, normal);
+    normal = worldFromEyeSpaceDir(cam_view(), normal);
 
     float4 rmaoMap = float4(0.0, 0.0, 0.0, 0.0);
     if (m.textures.z != -1) {
@@ -192,7 +192,7 @@ float4 main(PixelShaderInput IN) : SV_Target{
 
     float3 baseColor = float3(1.0, 1.0, 1.0);
     // with albedo from property or from texture
-    baseColor = m.color;
+    baseColor = m.color.xyz;
     if (m.textures.x != -1) {
         baseColor = material_textures.Sample(uSampler0[samplerIdx()], float3(IN.Texcoord.xy, m.textures.x)).xyz;
     }
@@ -201,7 +201,7 @@ float4 main(PixelShaderInput IN) : SV_Target{
     case 0: break;
     case 1: baseColor = normal; break;
     case 2: baseColor = surfNormal; break;
-    case 3: baseColor = mapNor; break;
+    case 3: baseColor = mapNor.xyz; break;
     }
 
     const float3 globalD = normalize(float3(0.0f, 1.0f, 0.0f));

--- a/src/graphics/drawables/ModelInspectorPart_vert.hlsl
+++ b/src/graphics/drawables/ModelInspectorPart_vert.hlsl
@@ -77,7 +77,7 @@ int uvmesh_triangle(float4 uvmesh_texel) {
 
 float4 uvSpaceClipPos(float2 uv) {
     float2 eyeUV = uv - float2(_uvCenterX, _uvCenterY);
-    return orthoClipFromEyeSpace(_projection.aspectRatio(),  2.0f * _uvScale
+    return orthoClipFromEyeSpace(cam_projection().aspectRatio(), 2.0f * _uvScale
     , 0.0f, 2.0f, float3( eyeUV, 1.0f));
 }
 
@@ -98,7 +98,7 @@ VertexShaderOutput main_uvspace(uint vidx : SV_VertexID) {
     VertexShaderOutput OUT;
 
     OUT.Position = uvSpaceClipPos(texcoord);
-    OUT.EyePos = OUT.Position;
+    OUT.EyePos = OUT.Position.xyz;
 
     OUT.Normal = float3(0.0, 0.0, 1.0);
     OUT.Texcoord = texcoord;
@@ -111,6 +111,9 @@ VertexShaderOutput transformAndPackOut(float3 position, float3 normal, float2 te
     VertexShaderOutput OUT;
     // Transform
     Transform _model = node_getWorldTransform(_nodeID);
+    Transform _view = cam_view();
+    Projection _projection = cam_projection();
+    
     position = worldFromObjectSpace(_model, position);
     float3 eyePosition = eyeFromWorldSpace(_view, position);
     float4 clipPos = clipFromEyeSpace(_projection, eyePosition);
@@ -141,6 +144,10 @@ VertexShaderOutput transformAndPackOutSprite(int sid, float spriteSize, float3 p
     VertexShaderOutput OUT;
     // Transform
     Transform _model = node_getWorldTransform(_nodeID);
+    Transform _view = cam_view();
+    Projection _projection = cam_projection();
+    float4 _viewport = cam_viewport();
+    
     position = worldFromObjectSpace(_model, position);
     float3 eyePosition = eyeFromWorldSpace(_view, position);
     float4 clipPos = clipFromEyeSpace(_projection, eyePosition);
@@ -155,6 +162,7 @@ VertexShaderOutput transformAndPackOutSprite(int sid, float spriteSize, float3 p
     OUT.Texcoord = texcoord;
     OUT.TriPos = trianglePos;
 
+    
     // Apply scaling to the sprite coord and offset pointcloud pos
     float2 sprite = float2(((sid == 1) ? 3.0 : -1.0), ((sid == 2) ? 3.0 : -1.0));
     const float2 invRes = float2(1.0 / _viewport.z, 1.0 / _viewport.w);
@@ -183,6 +191,10 @@ VertexShaderOutput transformAndPackOutSplat(int sid, float splatSize, float3 tan
 
     // Transform
     Transform _model = node_getWorldTransform(_nodeID);
+    Transform _view = cam_view();
+    Projection _projection = cam_projection();
+    float4 _viewport = cam_viewport();
+    
     position = worldFromObjectSpace(_model, position);
     float3 eyePosition = eyeFromWorldSpace(_view, position);
     float4 clipPos = clipFromEyeSpace(_projection, eyePosition);

--- a/src/graphics/drawables/ModelPart_vert.hlsl
+++ b/src/graphics/drawables/ModelPart_vert.hlsl
@@ -48,7 +48,9 @@ VertexShaderOutput main(uint vidx : SV_VertexID) {
     position += 0.0f * (barycenter - position);
 
     Transform _model = node_getWorldTransform(_nodeID);
-
+    Transform _view = cam_view();
+    Projection _projection = cam_projection();
+    
     position = worldFromObjectSpace(_model, position);
     float3 eyePosition = eyeFromWorldSpace(_view, position);
     float4 clipPos = clipFromEyeSpace(_projection, eyePosition);

--- a/src/graphics/drawables/PointCloud_vert.hlsl
+++ b/src/graphics/drawables/PointCloud_vert.hlsl
@@ -46,7 +46,10 @@ VertexShaderOutput main(uint vidT : SV_VertexID)
     float3 position = float3(BufferIn[vid].x, BufferIn[vid].y, BufferIn[vid].z);
 
     Transform _model = node_getWorldTransform(_instance.x);
-
+    Transform _view = cam_view();
+    Projection _projection = cam_projection();
+    float4 _viewport = cam_viewport();
+    
     position = worldFromObjectSpace(_model, position);
     float3 eyePosition = eyeFromWorldSpace(_view, position);
     float4 clipPos = clipFromEyeSpace(_projection, eyePosition);
@@ -107,6 +110,9 @@ VertexShaderOutput0 main0(VertexPosColor0 IN) {
 
     float3 position = IN.Position;
 
+    Transform _view = cam_view();
+    Projection _projection = cam_projection();
+    
     position = worldFromObjectSpace(_model, position);
     float3 eyePosition = eyeFromWorldSpace(_view, position);
     float4 clipPos = clipFromEyeSpace(_projection, eyePosition);

--- a/src/graphics/drawables/PostSceneDrawable.h
+++ b/src/graphics/drawables/PostSceneDrawable.h
@@ -37,8 +37,6 @@
 namespace graphics {
     class Device;
     using DevicePointer = std::shared_ptr<Device>;
-    class Camera;
-    using CameraPointer = std::shared_ptr<Camera>;
     class Buffer;
     using BufferPointer = std::shared_ptr<Buffer>;
     class PipelineState;

--- a/src/graphics/drawables/Primitive_vert.hlsl
+++ b/src/graphics/drawables/Primitive_vert.hlsl
@@ -38,6 +38,9 @@ VertexShaderOutput main(uint ivid : SV_VertexID)
     float3 color = float3(1.0, 1.0, 1.0);
 
     Transform _model = node_getWorldTransform(_nodeID);
+    Transform _view = cam_view();
+    Projection _projection = cam_projection();
+    
     Box _box;
     _box._center = float3(0.0, 0.0, 0.0);
     _box._size = float3(sx, sy,sz);

--- a/src/graphics/drawables/SkyDrawable_frag.hlsl
+++ b/src/graphics/drawables/SkyDrawable_frag.hlsl
@@ -22,7 +22,8 @@ float4 main_draw(PixelShaderInput IN) : SV_Target
     float3 dir = normalize(IN.wdir);
 
     float3 color = sky_fetchEnvironmentMap(dir, sky_map, uSampler0[0], uSampler0[1]);
-
+    Transform _view = cam_view();
+    float4 _viewport = cam_viewport();
     
     if (_drawControl.x == 1)
     { // Scopes

--- a/src/graphics/drawables/SkyDrawable_vert.hlsl
+++ b/src/graphics/drawables/SkyDrawable_vert.hlsl
@@ -18,7 +18,9 @@ struct VertexShaderOutput
 VertexShaderOutput main(uint ivid : SV_VertexID)
 {
     VertexShaderOutput OUT;
-
+    Transform _view = cam_view();
+    Projection _projection = cam_projection();
+    
     const int num_tris = 1;
     uint vid = ivid % (3 * num_tris);
     uint instance = ivid / (3 * num_tris);

--- a/src/graphics/drawables/TriangleSoupDrawable.cpp
+++ b/src/graphics/drawables/TriangleSoupDrawable.cpp
@@ -203,7 +203,7 @@ namespace graphics
         };
         auto descriptorSet = device->createDescriptorSet(descriptorSetInit);
 
-        // Assign the Camera UBO just created as the resource of the descriptorSet
+        // Assign the the resource of the descriptorSet
         graphics::DescriptorObjects descriptorObjects = {
             { graphics::DescriptorType::RESOURCE_BUFFER, triangleSoup.getVertexBuffer() },
             { graphics::DescriptorType::RESOURCE_BUFFER, triangleSoup.getIndexBuffer() }

--- a/src/graphics/drawables/TriangleSoup_frag.hlsl
+++ b/src/graphics/drawables/TriangleSoup_frag.hlsl
@@ -4,7 +4,7 @@ struct PixelShaderInput {
 };
 
 float4 main(PixelShaderInput IN) : SV_Target {
-    const float globalD = normalize(float3(0.0f, 1.0f, 0.0f));
+    const float3 globalD = normalize(float3(0.0f, 1.0f, 0.0f));
     const float globalI = 0.3f;
     const float3 lightD = normalize(float3(-1.0f, -1.0f, -1.0f));
     const float lightI = 0.7f;

--- a/src/graphics/drawables/TriangleSoup_vert.hlsl
+++ b/src/graphics/drawables/TriangleSoup_vert.hlsl
@@ -57,7 +57,8 @@ VertexShaderOutput main(uint vidx : SV_VertexID) {
     position += _triangleScale * (barycenter - position);
 
     Transform _model = node_getWorldTransform(_instance.x);
-
+    Transform _view = cam_view();
+    Projection _projection = cam_projection();
 
     position = worldFromObjectSpace(_model, position);
     float3 eyePosition = eyeFromWorldSpace(_view, position);

--- a/src/graphics/gpu/Resource.h
+++ b/src/graphics/gpu/Resource.h
@@ -87,7 +87,7 @@ namespace graphics {
 
         void* _cpuMappedAddress = nullptr;
 
-        // true if the texture needs to be uploaded through a Batch::uploadBuffer call
+        // true if the buffer needs to be uploaded through a Batch::uploadBuffer call
         // don't forget the transitions calls!
         // this needs to be checked and done explicitely before being able to fetch from that buffer in shaders 
         bool needUpload() const { return _needUpload; }

--- a/src/graphics/gpu/StructuredBuffer.h
+++ b/src/graphics/gpu/StructuredBuffer.h
@@ -1,0 +1,140 @@
+// StructuredBuffer.h 
+//
+// Sam Gateau - September 2022
+// 
+// MIT License
+//
+// Copyright (c) 2020 Sam Gateau
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#pragma once
+
+#include <mutex>
+#include "Resource.h"
+#include "Batch.h"
+
+namespace graphics {
+
+    // A StructuredBuffer is a managed dual cpu buffer / gpu buffer array of contiguous T elements
+    // The array (or buffer) is managing the storage of the elements.
+    // An element can be embedded in an individual instance by using the StructuredBuffer<T>::Handle struct
+    template <typename T>
+    struct StructuredBuffer {
+        using Index = uint32_t;
+        using Array = std::vector<T>;
+
+        mutable std::mutex  _cpu_access;
+
+        std::atomic_uint32_t _cpu_version{ 0xFFFFFFFF };
+        Array               _cpu_array;
+        Index               _cpu_capacity{ 0 };
+
+        uint32_t            _gpu_version{ 0xFFFFFFFF };
+        BufferPointer       _gpu_buffer;
+        Index               _gpu_capacity{ 0 };
+
+
+        inline const T* data(uint32_t index) const {
+            return _cpu_array.data() + index;
+        }
+        inline T* data(uint32_t index) {
+            return _cpu_array.data() + index;
+        }
+
+        inline void allocate_element(Index index, T* init) {
+            const std::lock_guard<std::mutex> access_lock(_cpu_access);
+            ++_cpu_version;
+            if (index < _cpu_array.size()) {
+                _cpu_array[index] = (init ? *init : T());
+            } else {
+                _cpu_array.emplace_back((init ? *init : T()));
+                _cpu_capacity = _cpu_array.capacity();
+            }
+        }
+
+        inline void reserve(const DevicePointer& device, Index capacity) {
+            // cpu array yeah
+            if (_cpu_capacity < capacity) {
+                const std::lock_guard<std::mutex> access_lock(_cpu_access);
+                _cpu_array.reserve(capacity);
+                _cpu_capacity = _cpu_array.capacity();
+                // cpu_version hasn't changed, values are the same
+            }
+
+            if (_gpu_capacity < capacity) {
+                const std::lock_guard<std::mutex> access_lock(_cpu_access);
+                _gpu_version = 0xFFFFFFFF; // reset gpu version to do a full recopy on next sync
+
+                graphics::BufferInit items_buffer_init{};
+                items_buffer_init.usage = graphics::ResourceUsage::RESOURCE_BUFFER;
+                items_buffer_init.hostVisible = true;
+                items_buffer_init.bufferSize = capacity * sizeof(T);
+                items_buffer_init.firstElement = 0;
+                items_buffer_init.numElements = capacity;
+                items_buffer_init.structStride = sizeof(T);
+                items_buffer_init.cpuDouble = true;
+                _gpu_buffer = device->createBuffer(items_buffer_init);
+
+                _gpu_capacity = capacity;
+            }
+        }
+
+        inline void sync_gpu_from_cpu(const BatchPointer& batch) {
+            // Capture the cpu version right now
+            auto cpu_version = _cpu_version.load();
+
+            // Schedule copy data from cpu to gpu here if versions are different
+            if (_gpu_version != cpu_version) {             
+                const std::lock_guard<std::mutex> cpulock(_cpu_access);
+
+                _gpu_version = cpu_version;
+
+                memcpy(_gpu_buffer->_cpuMappedAddress, _cpu_array.data(), _cpu_array.size() * sizeof(T));
+                
+                batch->resourceBarrierTransition(graphics::ResourceBarrierFlag::NONE, graphics::ResourceState::SHADER_RESOURCE, graphics::ResourceState::COPY_DEST, _gpu_buffer);
+                batch->uploadBuffer(_gpu_buffer);
+                batch->resourceBarrierTransition(graphics::ResourceBarrierFlag::NONE, graphics::ResourceState::COPY_DEST, graphics::ResourceState::SHADER_RESOURCE, _gpu_buffer);
+            }
+        }
+
+        using ReadLock = std::pair< const T*, std::lock_guard<std::mutex>>;
+        using WriteLock = std::pair< T*, std::lock_guard<std::mutex>>;
+
+        inline ReadLock read(Index index) const {
+            return  ReadLock(data(index), _cpu_access);
+        }
+        inline WriteLock write(Index index) {
+            ++_cpu_version; // Write access increment cpu version
+            return  WriteLock(data(index), _cpu_access);
+        }
+
+        struct Handle {
+            StructuredBuffer<T>* _buffer;
+            Index            _index{ 0xFFFFFFFF };
+
+            inline ReadLock read() const {
+                return  _buffer->read(_index);
+            }
+            inline WriteLock write() const {
+                return  _buffer->write(_index);
+            }
+        };
+    };
+}

--- a/src/graphics/gpu/Swapchain.h
+++ b/src/graphics/gpu/Swapchain.h
@@ -26,6 +26,7 @@
 //
 #pragma once
 
+#include <core/math/LinearAlgebra.h>
 #include <core/api.h>
 
 #include "gpu.h"
@@ -63,6 +64,8 @@ namespace graphics {
         uint32_t width() const { return _init.width; }
         uint32_t height() const { return _init.height; }
         PixelFormat colorBufferFormat() const { return _init.colorBufferFormat; }
+
+        core::vec4 viewportRect() const { return core::vec4( 0, 0, width(), height());}
 
     };
 }

--- a/src/graphics/gpu/gpu.h
+++ b/src/graphics/gpu/gpu.h
@@ -296,3 +296,4 @@ namespace graphics {
     };
 }
 
+#define createBuffer(init) _createBuffer(init, __FILE__)

--- a/src/graphics/render/Camera.cpp
+++ b/src/graphics/render/Camera.cpp
@@ -32,8 +32,9 @@
 
 using namespace graphics;
 
-Camera::Camera() {
-
+Camera::Camera(CameraStructBuffer::Handle handle) :
+    _camData(handle)
+{
 }
 
 Camera::~Camera() {
@@ -42,99 +43,93 @@ Camera::~Camera() {
 
 #define useLocks 1
 #ifdef useLocks 
-#define WriteLock() const std::lock_guard<std::mutex> cpulock(_camData._access); _camData._version++;
-#define ReadLock() const std::lock_guard<std::mutex> cpulock(_camData._access);
-
-#define WriteGPULock() const std::lock_guard<std::mutex> gpulock(_gpuData._access); _gpuData._version++;
-#define ReadGPULock() const std::lock_guard<std::mutex> gpulock(_gpuData._access);
+#define WriteLock() const std::lock_guard<std::mutex> cpulock(_camData._buffer->_cpu_access); _camData._buffer->_cpu_version++;
+#define ReadLock() const std::lock_guard<std::mutex> cpulock(_camData._buffer->_cpu_access);
 #else
 #define WriteLock()  _camData._version++;
 #define ReadLock() 
-
-#define WriteGPULock() _gpuData._version++;
-#define ReadGPULock()
 #endif
 
 void Camera::setView(const core::View& view) {
-    WriteLock();
-    _camData._data._view = view;
+    auto [d, l] = _camData.write();
+    d->_view = view;
 }
 
 core::View Camera::getView() const {
-    ReadLock();
-    return _camData._data._view;
+    auto [d, l] = _camData.read();
+    return d->_view;
 }
 
 void Camera::setEye(const core::vec3& pos) {
-    WriteLock();
-    _camData._data._view.setEye(pos);
+    auto [d, l] = _camData.write();
+    d->_view.setEye(pos);
 }
 core::vec3 Camera::getEye() const {
-    ReadLock();
-    return _camData._data._view.eye();
+    auto [d, l] = _camData.read();
+   return d->_view.eye();
 
 }
 
 void Camera::setOrientationFromRightUp(const core::vec3& right, const core::vec3& up) {
-    WriteLock();
-    _camData._data._view.setOrientationFromRightUp(right, up);
+    auto [d, l] = _camData.write();
+    d->_view.setOrientationFromRightUp(right, up);
 
 }
 void Camera::setOrientationFromFrontUp(const core::vec3& front, const core::vec3& up) {
-    WriteLock();
-    _camData._data._view.setOrientationFromFrontUp(front, up);
+    auto [d, l] = _camData.write();
+    d->_view.setOrientationFromFrontUp(front, up);
 
 }
 
 core::vec3 Camera::getRight() const {
-    ReadLock();
-    return _camData._data._view.right();
+    auto [d, l] = _camData.read();
+   return d->_view.right();
 }
 core::vec3 Camera::getUp() const {
-    ReadLock();
-    return _camData._data._view.up();
+    auto [d, l] = _camData.read();
+   return d->_view.up();
 }
 core::vec3 Camera::getBack() const {
-    ReadLock();
-    return _camData._data._view.back();
+    auto [d, l] = _camData.read();
+   return d->_view.back();
 }
 
 core::vec3 Camera::getLeft() const {
-    ReadLock();
-    return -_camData._data._view.right();
+    auto [d, l] = _camData.read();
+    return -d->_view.right();
 }
 core::vec3 Camera::getDown() const {
-    ReadLock();
-    return -_camData._data._view.up();
+    auto [d, l] = _camData.read();
+    return -d->_view.up();
 }
 core::vec3 Camera::getFront() const {
-    ReadLock();
-    return -_camData._data._view.back();
+    auto [d, l] = _camData.read();
+    return -d->_view.back();
 }
 
 
 void Camera::setProjection(const core::Projection& proj) {
-    WriteLock();
-    _camData._data._projection = proj;
+    auto [d, l] = _camData.write();
+    d->_projection = proj;
 }
 core::Projection Camera::getProjection() const {
-    ReadLock();
-    return _camData._data._projection;
+    auto [d, l] = _camData.read();
+   return d->_projection;
 }
 
 void Camera::setFocal(float focal) {
-    WriteLock();
-    _camData._data._projection.setFocal(focal);
+    auto [d, l] = _camData.write();
+    d->_projection.setFocal(focal);
 
 }
 float Camera::getFocal() const {
-    ReadLock();
-    return _camData._data._projection.focal();
+    auto [d, l] = _camData.read();
+   return d->_projection.focal();
 }
 
 float Camera::getFov(bool vertical) const {
-    ReadLock();
-    auto fovHalftan = _camData._data._projection.fovHalfTan(vertical);
+    auto [d, l] = _camData.read();
+    auto fovHalftan = d->_projection.fovHalfTan(vertical);
     auto fov = 2.0f * atanf(fovHalftan);
     return fov;
 }
@@ -144,97 +139,97 @@ float Camera::getFovDeg(bool vertical) const {
 }
 
 void Camera::setProjectionHeight(float projHeight) {
-    WriteLock();
-    _camData._data._projection.setHeight(projHeight);
+    auto [d, l] = _camData.write();
+    d->_projection.setHeight(projHeight);
 }
 
 float Camera::getProjectionHeight() const {
-    ReadLock();
-    return _camData._data._projection._height;
+    auto [d, l] = _camData.read();
+   return d->_projection._height;
 }
 
 float Camera::getProjectionWidth() const {
-    ReadLock();
-    return _camData._data._projection.width();
+    auto [d, l] = _camData.read();
+   return d->_projection.width();
 }
 
 void Camera::setAspectRatio(float aspectRatio) {
-    WriteLock();
-    _camData._data._projection.setAspectRatio(aspectRatio);
+    auto [d, l] = _camData.write();
+    d->_projection.setAspectRatio(aspectRatio);
 
 }
 float Camera::getAspectRatio() const {
-    ReadLock();
-    return _camData._data._projection.aspectRatio();
+    auto [d, l] = _camData.read();
+   return d->_projection.aspectRatio();
 }
 bool Camera::isLandscape() const {
-    ReadLock();
-    return _camData._data._projection.isLandscape();
+    auto [d, l] = _camData.read();
+   return d->_projection.isLandscape();
 }
 
 void Camera::setFar(float pfar) {
-    WriteLock();
-    _camData._data._projection.setFar(pfar);
+    auto [d, l] = _camData.write();
+    d->_projection.setFar(pfar);
 
 }
 float Camera::getFar() const {
-    ReadLock();
-    return _camData._data._projection._persFar;
+    auto [d, l] = _camData.read();
+   return d->_projection._persFar;
 }
 
 void Camera::setOrtho(bool enable) {
-    WriteLock();
-    _camData._data._projection.setOrtho(enable);
+    auto [d, l] = _camData.write();
+    d->_projection.setOrtho(enable);
 }
 bool Camera::isOrtho() const {
-    ReadLock();
-    return _camData._data._projection.isOrtho();
+    auto [d, l] = _camData.read();
+   return d->_projection.isOrtho();
 }
 
 void Camera::setOrthoHeight(float height) {
-    WriteLock();
-    _camData._data._projection.setOrthoHeight(height);
+    auto [d, l] = _camData.write();
+    d->_projection.setOrthoHeight(height);
 
 }
 float Camera::getOrthoHeight() const {
-    ReadLock();
-    return _camData._data._projection.orthoHeight();
+    auto [d, l] = _camData.read();
+   return d->_projection.orthoHeight();
 }
 float Camera::getOrthoWidth() const {
-    ReadLock();
-    return _camData._data._projection.orthoWidth();
+    auto [d, l] = _camData.read();
+   return d->_projection.orthoWidth();
 }
 void Camera::setOrthoSide(float orthoSide, bool vertical) {
-    WriteLock();
-    _camData._data._projection.setOrthoSide(orthoSide, vertical);
+    auto [d, l] = _camData.write();
+    d->_projection.setOrthoSide(orthoSide, vertical);
 }
 
 void Camera::setOrthoNear(float pnear) {
-    WriteLock();
-    _camData._data._projection.setOrthoNear(pnear);
+    auto [d, l] = _camData.write();
+    d->_projection.setOrthoNear(pnear);
 }
 float Camera::getOrthoNear() const {
-    ReadLock();
-    return _camData._data._projection._orthoNear;
+    auto [d, l] = _camData.read();
+   return d->_projection._orthoNear;
 }
 
 void Camera::setOrthoFar(float pfar) {
-    WriteLock();
-    _camData._data._projection.setOrthoFar(pfar);
+    auto [d, l] = _camData.write();
+    d->_projection.setOrthoFar(pfar);
 }
 float Camera::getOrthoFar() const {
-    ReadLock();
-    return _camData._data._projection._orthoFar;
+    auto [d, l] = _camData.read();
+   return d->_projection._orthoFar;
 }
 
 void Camera::setViewport(const core::ViewportRect& viewport) {
-    WriteLock();
-    _camData._data._viewport = viewport;
+    auto [d, l] = _camData.write();
+    d->_viewport = viewport;
 }
 
 core::ViewportRect Camera::getViewport() const {
-    ReadLock();
-    return _camData._data._viewport;
+    auto [d, l] = _camData.read();
+   return d->_viewport;
 }
 
 void Camera::setViewport(float width, float height, bool adjustAspectRatio) {
@@ -242,82 +237,46 @@ void Camera::setViewport(float width, float height, bool adjustAspectRatio) {
 }
 
 void Camera::setViewport(float oriX, float oriY, float width, float height, bool adjustAspectRatio) {
-    WriteLock();
-    _camData._data._viewport.setRect(core::vec4(0.f, 0.f, width, height));
+    auto [d, l] = _camData.write();
+    d->_viewport.setRect(core::vec4(0.f, 0.f, width, height));
     if (adjustAspectRatio) {
-        _camData._data._projection.setAspectRatio(_camData._data._viewport.width() / _camData._data._viewport.height());
+        d->_projection.setAspectRatio(d->_viewport.width() / d->_viewport.height());
     }
 }
 
 core::vec4 Camera::getViewportRect() const {
-    ReadLock();
-    return _camData._data._viewport.rect();
+    auto [d, l] = _camData.read();
+   return d->_viewport.rect();
 }
 
 float Camera::getViewportWidth() const {
-    ReadLock();
-    return _camData._data._viewport.width();
+    auto [d, l] = _camData.read();
+   return d->_viewport.width();
 }
 float Camera::getViewportHeight() const {
-    ReadLock();
-    return _camData._data._viewport.height();
+    auto [d, l] = _camData.read();
+   return d->_viewport.height();
 }
 
 float Camera::getOrthoPixelSize() const {
-    ReadLock();
-    return _camData._data._projection.orthoHeight() / _camData._data._viewport.height();
+    auto [d, l] = _camData.read();
+   return d->_projection.orthoHeight() / d->_viewport.height();
 }
 float Camera::getPerspPixelSize(float depth) const {
-    ReadLock();
-    return _camData._data._projection.evalHeightAt(depth) / _camData._data._viewport.height();
-}
-
-void Camera::allocateGPUData(const DevicePointer& device) {
-    // CReate a gpu buffer to hold the camera
-    graphics::BufferInit uboInit;
-    uboInit.usage = ResourceUsage::UNIFORM_BUFFER;
-    uboInit.bufferSize = sizeof(CameraData);
-    uboInit.hostVisible = true;
-    _gpuData._buffer = device->createBuffer(uboInit);
-
-    // and then copy data there
-    ReadLock();
-    memcpy(_gpuData._buffer->_cpuMappedAddress, &_camData._data, sizeof(CameraData));
-
-    // sync the data version
-    _gpuData._version = _camData._version;
-}
-
-bool Camera::updateGPUData() {
-    // TODO make the version an atomic to be thread safe...
-    bool needCopy = (_gpuData._version != _camData._version);
-     // copy data from tcpu to gpu here if versions are different
-    if (needCopy) {
-        ReadLock();
-        WriteGPULock();
-        memcpy(_gpuData._buffer->_cpuMappedAddress, &_camData._data, sizeof(CameraData));
-
-        // sync the data version
-        _gpuData._version = _camData._version;
-    }
-    return needCopy;
-}
-
-BufferPointer Camera::getGPUBuffer() const {
-    ReadGPULock();
-    return _gpuData._buffer;
+    auto [d, l] = _camData.read();
+   return d->_projection.evalHeightAt(depth) / d->_viewport.height();
 }
 
 void Camera::pan(float deltaRight, float deltaUp) {
-    WriteLock();
-    auto& view = _camData._data._view;
+    auto [d, l] = _camData.write();
+    auto& view = d->_view;
     view.setEye( view.eye() + view.right() * deltaRight + view.up() * deltaUp );
 }
 
 void Camera::dolly(float deltaBack) {
-    WriteLock();
-    auto oriView = _camData._data._view;
-    auto& nextView = _camData._data._view;
+    auto [d, l] = _camData.write();
+    auto oriView = d->_view;
+    auto& nextView = d->_view;
 
     // PE is the vector from Pivot to Eye position
     auto boomVecWS = oriView.back() * (deltaBack);
@@ -329,9 +288,9 @@ void Camera::dolly(float deltaBack) {
 }
 
 void Camera::orbit(float boomLength, float deltaRight, float deltaUp) {
-    WriteLock();
-    auto oriView = _camData._data._view;
-    auto& nextView = _camData._data._view;
+    auto [d, l] = _camData.write();
+    auto oriView = d->_view;
+    auto& nextView = d->_view;
 
     // PE is the vector from Pivot to Eye position
     auto boomVecWS = oriView.back() * (-boomLength);
@@ -355,8 +314,8 @@ void Camera::orbit(float boomLength, float deltaRight, float deltaUp) {
 }
 
 void Camera::orbitHorizontal(float boomLength, float deltaRight, float deltaUp) {
-    WriteLock();
-    _camData._data._view.orbitHorizontal(boomLength, deltaRight, deltaUp);
+    auto [d, l] = _camData.write();
+    d->_view.orbitHorizontal(boomLength, deltaRight, deltaUp);
 }
 
 float Camera::boom(float boomLength, float delta) {
@@ -421,9 +380,9 @@ void Camera::lookFrom(const core::vec3& lookDirection) {
 }
 
 core::vec2 Camera::eyeSpaceFromImageSpace2D(float x, float y) const {
-    ReadLock();
-    const auto& vr = _camData._data._viewport._rect;
-    const auto& proj = _camData._data._projection;
+    auto [d, l] = _camData.read();
+    const auto& vr = d->_viewport._rect;
+    const auto& proj = d->_projection;
 
     auto m_nc = core::ViewportRect::normalizedSpaceFromImageSpace(vr, x, y);
     if (proj.isOrtho()) {
@@ -436,81 +395,28 @@ core::vec2 Camera::eyeSpaceFromImageSpace2D(float x, float y) const {
 
 
 
-CamID CameraStore::newID() {
-    return _indexTable.allocate();
+void CameraStore::reserve(const DevicePointer& device, uint32_t capacity) {
+    _cameraStructBuffer.reserve(device, capacity);
 }
 
-Cam CameraStore::allocate(const Cam& cam) {
+CameraPointer CameraStore::createCamera() {
 
-    CamID new_id = cam.id();
-    bool allocated = new_id == (_indexTable.getNumAllocatedElements() - 1);
+    auto alloc = _indexTable.allocate();
 
-    if (allocated) {
-        _cameras.push_back(cam);
+    _cameraStructBuffer.allocate_element(alloc.index, &CameraData());
+
+    CameraPointer camera(new Camera({ &_cameraStructBuffer, alloc.index }));
+
+    if (alloc.recycle) {
+        _cameras[alloc.index] = camera;
     } else {
-        _cameras[new_id] = (cam);
+        _cameras.push_back(camera);
     }
 
-    if (new_id < _num_buffers_elements) {
-        reinterpret_cast<CameraData*>(_cameras_buffer->_cpuMappedAddress)[new_id] = (camera);
-    }
-
-    return cam;
-}
-
-void CameraStore::free(CamID index) {
-    if (_indexTable.isValid(index)) {
-        _indexTable.free(index);
-        _cameras[index] = Cam();
-    }
-}
-
-void CameraStore::freeAll() {
-
+    return camera;
 }
 
 
-Item CameraStore::getValidItemAt(ItemID startIndex) const {
-    if (startIndex < _items.size()) {
-        do {
-            const auto* item = _items.data() + startIndex;
-            if (item->isValid()) {
-                return (*item);
-            }
-            startIndex++;
-        } while (startIndex < _items.size());
-    }
-    return Item::null;
-}
-
-void CameraStore::resizeBuffers(const DevicePointer& device, uint32_t numElements) {
-
-    if (_num_buffers_elements < numElements) {
-        auto capacity = (numElements);
-
-        graphics::BufferInit items_buffer_init{};
-        items_buffer_init.usage = graphics::ResourceUsage::RESOURCE_BUFFER;
-        items_buffer_init.hostVisible = true;
-        items_buffer_init.bufferSize = capacity * sizeof(ItemInfo);
-        items_buffer_init.firstElement = 0;
-        items_buffer_init.numElements = capacity;
-        items_buffer_init.structStride = sizeof(ItemInfo);
-
-        _items_buffer = device->createBuffer(items_buffer_init);
-
-        _num_buffers_elements = capacity;
-    }
-}
-
-void CameraStore::syncBuffer() {
-    if (_touchedElements.empty()) {
-        return;
-    }
-
-    if (_itemInfos.size() < _num_buffers_elements) {
-        for (auto index : _touchedElements) {
-            reinterpret_cast<ItemInfo*>(_items_buffer->_cpuMappedAddress)[index] = _itemInfos[index];
-        }
-        _touchedElements.clear();
-    }
+void CameraStore::syncGPUBuffer(const BatchPointer& batch) {
+    _cameraStructBuffer.sync_gpu_from_cpu(batch);
 }

--- a/src/graphics/render/Camera_inc.hlsl
+++ b/src/graphics/render/Camera_inc.hlsl
@@ -6,15 +6,39 @@
 
 
 // Camera buffer
-cbuffer UniformBlock0 : register(b10) {
+/*cbuffer UniformBlock0 : register(b10) {
     //float4x3 _view;
+    Transform _view;
+    Projection _projection;
+    float4 _viewport;
+};*/
+
+
+struct Camera {
+  //float4x3 _view;
     Transform _view;
     Projection _projection;
     float4 _viewport;
 };
 
-float cam_pixelSizeAt(float eyeDepth)
-{
+StructuredBuffer<Camera> camera_array : register(t19);
+
+Transform cam_view() {
+    return camera_array[0]._view;
+}
+
+Projection cam_projection() {
+    return camera_array[0]._projection;
+}
+
+float4 cam_viewport() {
+    return camera_array[0]._viewport;
+}
+    
+float cam_pixelSizeAt(float eyeDepth) {
+    Projection _projection = cam_projection();
+    float4 _viewport = cam_viewport();
+    
     float pixelSize = _projection.sensorHeight() / _viewport.w;
     return abs(eyeDepth) * pixelSize / _projection.focal();
 }

--- a/src/graphics/render/Drawable.cpp
+++ b/src/graphics/render/Drawable.cpp
@@ -34,7 +34,7 @@ using namespace graphics;
 Drawable Drawable::null;
 
 DrawableID DrawableStore::newID() {
-    return _indexTable.allocate();
+    return _indexTable.allocate().index;
 }
 
 Drawable DrawableStore::allocate(Drawable drawable) {

--- a/src/graphics/render/Item.h
+++ b/src/graphics/render/Item.h
@@ -62,6 +62,10 @@ namespace graphics {
         bool isVisible() const { return _self->isVisible(); }
         bool toggleVisible() { return _self->toggleVisible(); }
 
+        void setAsCamera(bool asCamera) { _self->setCamera(asCamera); }
+        bool isCamera() const { return _self->isCamera(); }
+        bool toggleCamera() { return _self->toggleCamera(); }
+
         NodeID getNodeID() const { return _self->getNodeID(); }
 
         DrawableID getDrawableID() const { return _self->getDrawableID(); }
@@ -86,6 +90,11 @@ namespace graphics {
             void setVisible(bool visible);
             bool isVisible() const;
             bool toggleVisible();
+
+            void setCamera(bool isCam);
+            bool isCamera() const;
+            bool toggleCamera();
+
             void setNode(Node node);
             NodeID getNodeID() const;
             void setDrawable(Drawable drawable);
@@ -109,13 +118,24 @@ namespace graphics {
         Item allocate(const Scene* scene, NodeID node, DrawableID drawable, ItemID owner = INVALID_ITEM_ID);
     public:
 
+        enum Flags {
+            IS_VISIBLE = 0x00000001,
+            IS_CAMERA = 0x00000002,
+        };
+
         struct ItemInfo {
             NodeID _nodeID{ INVALID_NODE_ID };
             DrawableID _drawableID{ INVALID_DRAWABLE_ID };
             ItemID _groupID{ INVALID_ITEM_ID };
-            uint32_t _isVisible{ true };
+            uint32_t _flags{ IS_VISIBLE };
 
-            inline bool toggleVisible() { _isVisible = !_isVisible; return _isVisible; }
+            inline void setVisible(bool visible) { if (isVisible() != visible) toggleVisible(); }
+            inline bool isVisible() const { return ((_flags & IS_VISIBLE) != 0); }
+            inline bool toggleVisible() { _flags ^= IS_VISIBLE; return isVisible(); }
+
+            inline void setVisible(bool camera) { if (isCamera() != camera) toggleCamera(); }
+            inline bool isCamera() const { return ((_flags & IS_CAMERA) != 0); }
+            inline bool toggleCamera() { _flags ^= IS_CAMERA; return isCamera(); }
         };
 
         Item createItem(const Scene* scene, Node node, Drawable drawable, ItemID owner = INVALID_ITEM_ID);
@@ -147,9 +167,13 @@ namespace graphics {
         void syncBuffer();
     };
 
-    inline void Item::Concept::setVisible(bool visible) { _store->editInfo(_id)._isVisible = visible; }
-    inline bool Item::Concept::isVisible() const { return _store->getInfo(_id)._isVisible; }
+    inline void Item::Concept::setVisible(bool visible) { _store->editInfo(_id).setVisible(visible); }
+    inline bool Item::Concept::isVisible() const { return _store->getInfo(_id).isVisible(); }
     inline bool Item::Concept::toggleVisible() { return _store->editInfo(_id).toggleVisible(); }
+    inline void Item::Concept::setCamera(bool isCamera) { _store->editInfo(_id).setCamera(isCamera); }
+    inline bool Item::Concept::isCamera() const { return _store->getInfo(_id).isCamera(); }
+    inline bool Item::Concept::toggleCamera() { return _store->editInfo(_id).toggleCamera(); }
+
     inline void Item::Concept::setNode(Node node) { _store->editInfo(_id)._nodeID = node.id(); }
     inline NodeID Item::Concept::getNodeID() const { return _store->getInfo(_id)._nodeID; }
     inline void Item::Concept::setDrawable(Drawable drawable) { _store->editInfo(_id)._drawableID = drawable.id(); }

--- a/src/graphics/render/Renderer.h
+++ b/src/graphics/render/Renderer.h
@@ -28,6 +28,7 @@
 
 #include "render.h"
 #include <functional>
+#include "Camera.h"
 
 namespace graphics {
 

--- a/src/graphics/render/Scene.h
+++ b/src/graphics/render/Scene.h
@@ -34,13 +34,25 @@
 #include "render/Transform.h"
 #include "render/Drawable.h"
 #include "render/Item.h"
+#include "render/Camera.h"
 
 namespace graphics {
     using UserID  = uint32_t;  
 
+    struct VISUALIZATION_API SceneInit {
+        DevicePointer device; // need a device to create the scene
+
+        // And allocate all the capacities for the various stores
+        int32_t items_capacity = 1000; 
+        int32_t nodes_capacity = 1000;
+        int32_t drawables_capacity = 100;
+        int32_t cameras_capacity = 10;
+    };
+
     class VISUALIZATION_API Scene {
     public:
-        Scene();
+       
+        Scene(const SceneInit& init);
         ~Scene();
 
         // Items
@@ -83,18 +95,20 @@ namespace graphics {
 
         // Cameras
         CameraStore _cameras;
-        Cam getCam(CamID camId) const;
-        template <typename T>
-        Cam createCam(T& x) {
-            return _cams.createCam(x);
+        CameraPointer getCamera(CameraID camId) const;
+        CameraPointer createCamera() {
+            return _cameras.createCamera();
         }
 
         // Bound;
         void updateBounds();
         const core::Bounds& getBounds() const { return _bounds; }
 
-        SkyPointer _sky;
         
+        // TODO: Find a better way....
+        SkyDrawableFactory_sp _skyFactory;
+        Sky_sp _sky;
+
     protected:
 
         IDToIndices _idToIndices;
@@ -102,4 +116,6 @@ namespace graphics {
         core::Bounds _bounds;
     };
 
+    // Standard function to synchronise all the gpu resources required by the scene for the frame being constructed
+    void syncSceneResourcesForFrame(const ScenePointer& scene, const BatchPointer& batch);
 }

--- a/src/graphics/render/Scene.h
+++ b/src/graphics/render/Scene.h
@@ -76,10 +76,17 @@ namespace graphics {
         // Drawables
         DrawableStore _drawables;
         Drawable getDrawable(DrawableID drawableId) const;
-
         template <typename T>
         Drawable createDrawable(T& x) {
             return _drawables.createDrawable(x);
+        }
+
+        // Cameras
+        CameraStore _cameras;
+        Cam getCam(CamID camId) const;
+        template <typename T>
+        Cam createCam(T& x) {
+            return _cams.createCam(x);
         }
 
         // Bound;

--- a/src/graphics/render/Transform.cpp
+++ b/src/graphics/render/Transform.cpp
@@ -35,22 +35,21 @@ using namespace graphics;
 
 TransformTree::NodeID TransformTree::allocate(const core::mat4x3& rts, NodeID parent) {
 
-    NodeID new_node_id = _indexTable.allocate();
-    bool allocated = new_node_id == (_indexTable.getNumAllocatedElements() - 1);
+    auto new_node_alloc = _indexTable.allocate();
 
-    if (allocated) {
+    if (new_node_alloc.recycle) {
+        _treeNodes[new_node_alloc.index] = Node();
+        _nodeTransforms[new_node_alloc.index] = rts;
+        _worldTransforms[new_node_alloc.index] = rts;
+    } else {
         _treeNodes.push_back(Node());
         _nodeTransforms.push_back(rts);
         _worldTransforms.push_back(rts);
-    } else {
-        _treeNodes[new_node_id] = Node();
-        _nodeTransforms[new_node_id] = rts;
-        _worldTransforms[new_node_id] = rts;
     }
 
-    attachNode(new_node_id, parent);
+    attachNode(new_node_alloc.index, parent);
 
-    return new_node_id;
+    return new_node_alloc.index;
 }
 
 TransformTree::NodeIDs TransformTree::allocateBranch(NodeID rootParent, const std::vector<core::mat4x3>& transforms, const NodeIDs& parentsOffsets) {

--- a/src/graphics/render/Viewport.h
+++ b/src/graphics/render/Viewport.h
@@ -35,10 +35,20 @@
 
 namespace graphics {
 
+    struct VISUALIZATION_API ViewportInit {
+        ScenePointer    scene;
+        DevicePointer   device;
+        RenderCallback  postSceneRC = nullptr;
+        CameraID        cameraID = 0;
+    };
+
     class VISUALIZATION_API Viewport {
     public:
-        Viewport(const ScenePointer& scene, const CameraPointer& camera, const DevicePointer& device, RenderCallback postSceneRC = nullptr);
+        Viewport(const ViewportInit& init);
         ~Viewport();
+
+        void setCamera(CameraID camID) { _cameraID = camID; }
+        CameraID getCamera() const { return _cameraID; }
 
         void present(const SwapchainPointer& swapchain);
 
@@ -52,7 +62,6 @@ namespace graphics {
         void renderScene(RenderArgs& args);
 
         ScenePointer _scene;
-        CameraPointer _camera;
         DevicePointer _device;
         RendererPointer _renderer;
 
@@ -63,7 +72,9 @@ namespace graphics {
         BatchTimerPointer _batchTimer;
 
         DescriptorSetPointer _viewPassDescriptorSet;
-        RootDescriptorLayoutPointer _viewPassRootLayout;
+
+        // Bag of interesting constants for the Viewport ?
+        CameraID _cameraID = 0;
 
     };
 }

--- a/src/graphics/render/render.h
+++ b/src/graphics/render/render.h
@@ -49,12 +49,17 @@ namespace graphics {
 
     class Viewport;
     using ViewportPointer = std::shared_ptr<Viewport>;
+    struct ViewportInit;
 
     class Mesh;
     using MeshPointer = std::shared_ptr<Mesh>;
 
     class Sky;
     using SkyPointer = std::shared_ptr<Sky>;
+    using Sky_sp = SkyPointer;
+
+    class SkyDrawableFactory;
+    using SkyDrawableFactory_sp = std::shared_ptr<SkyDrawableFactory>;
 
 }
 

--- a/test/pico_04/pico_four.cpp
+++ b/test/pico_04/pico_four.cpp
@@ -45,6 +45,7 @@
 #include <graphics/render/Scene.h>
 #include <graphics/render/Viewport.h>
 
+
 #include <document/PointCloud.h>
 #include <graphics/drawables/PointcloudDrawable.h>
 
@@ -111,20 +112,18 @@ int main(int argc, char *argv[])
     auto gpuDevice = graphics::Device::createDevice(deviceInit);
 
     // Second a Scene
-    auto scene = std::make_shared<graphics::Scene>();
-    scene->_items.resizeBuffers(gpuDevice, 200);
-    scene->_nodes.resizeBuffers(gpuDevice, 200);
-    scene->_drawables.resizeBuffers(gpuDevice, 200);
+    auto scene = std::make_shared<graphics::Scene>(graphics::SceneInit{gpuDevice});
   
     // A Camera to look at the scene
-    auto camera = std::make_shared<graphics::Camera>();
+    auto camera = scene->createCamera();
     camera->setViewport(1280.0f, 720.0f, true); // setting the viewport size, and yes adjust the aspect ratio
     camera->setOrientationFromRightUp({ 1.f, 0.f, 0.0f }, { 0.f, 1.f, 0.f });
     camera->setProjectionHeight(0.1f);
     camera->setFocal(0.1f);
 
     // The viewport managing the rendering of the scene from the camera
-    auto viewport = std::make_shared<graphics::Viewport>(scene, camera, gpuDevice);
+    auto viewport = std::make_shared<graphics::Viewport>(graphics::ViewportInit{ scene, gpuDevice, nullptr, camera->id() });
+
 
     // A point cloud drawable factory
     auto pointCloudDrawableFactory = std::make_shared<graphics::PointCloudDrawableFactory>();
@@ -307,8 +306,6 @@ int main(int argc, char *argv[])
             }*/
         }
 
-        scene->_items.syncBuffer();
-        scene->_nodes.updateTransforms();
         camControl->update(std::chrono::duration_cast<std::chrono::microseconds>(frameSample._frameDuration));
 
         // Render!

--- a/test/pico_ocean/pico_ocean.cpp
+++ b/test/pico_ocean/pico_ocean.cpp
@@ -86,20 +86,17 @@ int main(int argc, char *argv[])
     auto gpuDevice = graphics::Device::createDevice(deviceInit);
 
     // Second a Scene
-    auto scene = std::make_shared<graphics::Scene>();
-    scene->_items.resizeBuffers(gpuDevice, 250000);
-    scene->_nodes.resizeBuffers(gpuDevice, 250000);
-    scene->_drawables.resizeBuffers(gpuDevice, 250000);
+    auto scene = std::make_shared<graphics::Scene>(graphics::SceneInit{gpuDevice});
   
     // A Camera to look at the scene
-    auto camera = std::make_shared<graphics::Camera>();
+    auto camera = scene->createCamera();
     camera->setViewport(1280.0f, 720.0f, true); // setting the viewport size, and yes adjust the aspect ratio
     camera->setOrientationFromRightUp({ 1.f, 0.f, 0.0f }, { 0.f, 1.f, 0.f });
     camera->setProjectionHeight(0.1f);
     camera->setFocal(0.1f);
 
     // The viewport managing the rendering of the scene from the camera
-    auto viewport = std::make_shared<graphics::Viewport>(scene, camera, gpuDevice);
+    auto viewport = std::make_shared<graphics::Viewport>(graphics::ViewportInit{ scene, gpuDevice, nullptr, camera->id() });
 
     // Some nodes to layout the scene and animate objects
     auto node0 = scene->createNode(core::mat4x3(), -1);
@@ -175,8 +172,6 @@ int main(int argc, char *argv[])
             updateHeights(t);
         }
 
-        scene->_items.syncBuffer();
-        scene->_nodes.updateTransforms();
         camControl->update(std::chrono::duration_cast<std::chrono::microseconds>(frameSample._frameDuration));
 
         // Render!

--- a/test/pico_terrain/pico_terrain.cpp
+++ b/test/pico_terrain/pico_terrain.cpp
@@ -121,20 +121,17 @@ int main(int argc, char *argv[])
     auto gpuDevice = graphics::Device::createDevice(deviceInit);
 
     // Second a Scene
-    auto scene = std::make_shared<graphics::Scene>();
-    scene->_items.resizeBuffers(gpuDevice, 250000);
-    scene->_nodes.resizeBuffers(gpuDevice, 250000);
-    scene->_drawables.resizeBuffers(gpuDevice, 250000);
+    auto scene = std::make_shared<graphics::Scene>(graphics::SceneInit{gpuDevice});
   
     // A Camera to look at the scene
-    auto camera = std::make_shared<graphics::Camera>();
+    auto camera = scene->createCamera();
     camera->setViewport(1280.0f, 720.0f, true); // setting the viewport size, and yes adjust the aspect ratio
     camera->setOrientationFromRightUp({ 1.f, 0.f, 0.0f }, { 0.f, 1.f, 0.f });
     camera->setProjectionHeight(0.1f);
     camera->setFocal(0.1f);
 
     // The viewport managing the rendering of the scene from the camera
-    auto viewport = std::make_shared<graphics::Viewport>(scene, camera, gpuDevice);
+    auto viewport = std::make_shared<graphics::Viewport>(graphics::ViewportInit{ scene, gpuDevice, nullptr, camera->id() });
 
     // Some nodes to layout the scene and animate objects
     auto node0 = scene->createNode(core::mat4x3(), -1);
@@ -156,7 +153,7 @@ int main(int argc, char *argv[])
 
     auto gzdrawable_item = scene->createDrawable(*gizmoDrawableFactory->createItemGizmo(gpuDevice));
     gizmoDrawableFactory->allocateDrawcallObject(gpuDevice, scene, gzdrawable_item.as<graphics::ItemGizmo>());
-    gzdrawable_item.as<graphics::ItemGizmo>().items.resize(scene->_items._items_buffer->numElements());
+    gzdrawable_item.as<graphics::ItemGizmo>().items.resize(scene->_items.getGPUBuffer()->numElements());
     auto gzitem_item = scene->createItem(graphics::Node::null, gzdrawable_item);
     gzitem_item.setVisible(false);
 
@@ -209,8 +206,6 @@ int main(int argc, char *argv[])
         if (doAnimate) {
         }
 
-        scene->_items.syncBuffer();
-        scene->_nodes.updateTransforms();
         camControl->update(std::chrono::duration_cast<std::chrono::microseconds>(frameSample._frameDuration));
 
         // Render!


### PR DESCRIPTION
in this pr, we are exploring how to create a new store for the cameras
a camera is created from the scene and added in the CameraStore
The camera store is managing a gpu buffer which is doubled on the cpu side which contains the array of Camera DATA struct.
the camera are just an interface on top of the pair {store, index}
the gpubuffer containing the array of camera data replaces the ubo that was used before and tied to the one camera.
THe goal ultimately being that we refer dynamically to dynmically from their index
For now, we always use index 0

In order to reuse the same concepts for the other sotres of the scene (item , transform node, drawable etc) we are introducing the gpu class StructuredBuffer which is managing the dual cpu/gpu buffer under a single object, it behaves like a standard vector with N elements and a capacity and the synchronization from cpu to gpu

and voila