### PR TITLE
Iterating on Draw, improving perf with superluminal

### DIFF
--- a/src/graphics/d3d12/D3D12Backend.h
+++ b/src/graphics/d3d12/D3D12Backend.h
@@ -196,6 +196,8 @@ namespace graphics {
         D3D12_CPU_DESCRIPTOR_HANDLE _dsv;
     };
 
+    class D3D12PipelineStateBackend;
+    class D3D12DescriptorSetBackend;
     class D3D12BatchBackend : public Batch {
     public:
         friend class D3D12Backend;
@@ -226,8 +228,8 @@ namespace graphics {
         void resourceBarrierRW(
             ResourceBarrierFlag flag, const TexturePointer& texture, uint32_t subresource) override;
 
-        void setViewport(const core::vec4& viewport) override;
-        void setScissor(const core::vec4& scissor) override;
+        void _setViewport(const core::vec4& viewport) override;
+        void _setScissor(const core::vec4& scissor) override;
 
         void bindDescriptorHeap(const DescriptorHeapPointer& descriptorHeap);
 
@@ -265,6 +267,10 @@ namespace graphics {
         UINT _currentGraphicsRootLayout_samplerRootIndex = 0;
         UINT _currentComputeRootLayout_setRootIndex = 0;
         UINT _currentComputeRootLayout_samplerRootIndex = 0;
+
+        D3D12PipelineStateBackend* _currentGraphicsPipeline = nullptr;
+
+        D3D12DescriptorSetBackend* _currentGraphicsDescriptorSets[4] = { nullptr, nullptr, nullptr, nullptr };
 
         BatchTimerPointer _timer;
 

--- a/src/graphics/d3d12/D3D12Backend_Batch.cpp
+++ b/src/graphics/d3d12/D3D12Backend_Batch.cpp
@@ -230,7 +230,7 @@ void D3D12BatchBackend::resourceBarrierRW(
     _commandList->ResourceBarrier(1, &barrier);
 }
 
-void D3D12BatchBackend::setViewport(const core::vec4 & viewport) {
+void D3D12BatchBackend::_setViewport(const core::vec4 & viewport) {
     D3D12_VIEWPORT dxViewport;
     dxViewport.TopLeftX = viewport.x;
     dxViewport.TopLeftY = viewport.y;
@@ -242,7 +242,7 @@ void D3D12BatchBackend::setViewport(const core::vec4 & viewport) {
     _commandList->RSSetViewports(1, &dxViewport);
 }
 
-void D3D12BatchBackend::setScissor(const core::vec4 & scissor) {
+void D3D12BatchBackend::_setScissor(const core::vec4 & scissor) {
     D3D12_RECT dxRect;
     dxRect.left = (LONG) scissor.x;
     dxRect.top = (LONG) scissor.y;
@@ -286,6 +286,11 @@ void D3D12BatchBackend::bindRootDescriptorLayout(PipelineType type, const RootDe
         _currentGraphicsRootLayout_setRootIndex = rdl->_cbvsrvuav_rootIndex;
         _currentGraphicsRootLayout_samplerRootIndex = rdl->_sampler_rootIndex;
         _commandList->SetGraphicsRootSignature(dxRS.Get());
+
+        _currentGraphicsDescriptorSets[0] =
+            _currentGraphicsDescriptorSets[1] =
+            _currentGraphicsDescriptorSets[2] =
+            _currentGraphicsDescriptorSets[3] = nullptr;
     } break;
     case PipelineType::COMPUTE: {
         _currentComputeRootLayout_setRootIndex = rdl->_cbvsrvuav_rootIndex;
@@ -301,6 +306,7 @@ void D3D12BatchBackend::bindPipeline(const PipelineStatePointer& pipeline) {
     if (dpso->getType() == PipelineType::RAYTRACING) {
         _commandList->SetPipelineState1(dpso->_stateObject.Get());
     } else {
+        if (dpso == _currentGraphicsPipeline) return; // check the cache, if the same pso then skip!
 
         auto dxPso = dpso->_pipelineState;
         _commandList->SetPipelineState(dxPso.Get());
@@ -312,6 +318,8 @@ void D3D12BatchBackend::bindPipeline(const PipelineStatePointer& pipeline) {
         }
         else if (dpso->getType() == PipelineType::COMPUTE) {
         }
+
+        _currentGraphicsPipeline = dpso;
     }
 }
 
@@ -321,9 +329,12 @@ void D3D12BatchBackend::bindDescriptorSet(PipelineType type, const DescriptorSet
     switch (type) {
     case PipelineType::GRAPHICS: {
         if (dxds->_cbvsrvuav_rootIndex >= 0) {
+            if (_currentGraphicsDescriptorSets[descriptorSet->_init._bindSetSlot] == dxds)
+                return;
             _commandList->SetGraphicsRootDescriptorTable(
                 _currentGraphicsRootLayout_setRootIndex + descriptorSet->_init._bindSetSlot,
                 dxds->_cbvsrvuav_GPUHandle);
+            _currentGraphicsDescriptorSets[descriptorSet->_init._bindSetSlot] = dxds;
         }
         if (dxds->_sampler_rootIndex >= 0) {
             _commandList->SetGraphicsRootDescriptorTable(

--- a/src/graphics/drawables/DashboardDraw.h
+++ b/src/graphics/drawables/DashboardDraw.h
@@ -55,13 +55,7 @@ namespace graphics {
         ~DashboardDrawFactory();
 
         // Create DashboardDraw
-        graphics::DashboardDraw* createDraw(const graphics::DevicePointer& device);
-
-        // Create Drawcall object drawing the DashboardDraw in the rendering context
-        void allocateDrawcallObject(
-            const graphics::DevicePointer& device,
-            const graphics::ScenePointer& scene,
-            graphics::DashboardDraw& primitive);
+        graphics::DashboardDraw createDraw(const graphics::DevicePointer& device);
 
         // Read / write shared uniforms
         const DashboardDrawUniforms& getUniforms() const { return (*_sharedUniforms); }
@@ -73,14 +67,16 @@ namespace graphics {
 
         // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
         void allocateGPUShared(const graphics::DevicePointer& device);
+
+        // Create Drawcall object drawing the DashboardDraw in the rendering context
+        void allocateDrawcallObject(const graphics::DevicePointer& device, graphics::DashboardDraw& primitive);
     };
-    using DashboardDrawFactoryPointer = std::shared_ptr< DashboardDrawFactory>;
+
+    using DashboardDrawFactoryPointer = std::shared_ptr<DashboardDrawFactory>;
 
 
-    class VISUALIZATION_API DashboardDraw {
+    struct VISUALIZATION_API DashboardDraw {
     public:
-
-        void swapUniforms(const DashboardDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
         const DashboardDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
         core::vec3 _size{ 1.0f };

--- a/src/graphics/drawables/GizmoDraw.h
+++ b/src/graphics/drawables/GizmoDraw.h
@@ -67,30 +67,15 @@ namespace graphics {
 
     class VISUALIZATION_API GizmoDrawFactory {
         // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
-        void allocateGPUShared(const graphics::DevicePointer& device);
+        void allocateGPUShared(const DevicePointer& device, const ScenePointer& scene);
 
     public:
-        GizmoDrawFactory(const graphics::DevicePointer& device);
+        GizmoDrawFactory(const DevicePointer& device, const ScenePointer& scene);
         ~GizmoDrawFactory();
 
         // Create GizmoDraw for a given Gizmo document, building the gpu vertex buffer
-        graphics::NodeGizmo* createNodeGizmo(const graphics::DevicePointer& device);
-        graphics::ItemGizmo* createItemGizmo(const graphics::DevicePointer& device);
-        graphics::CameraGizmo* createCameraGizmo(const graphics::DevicePointer& device);
-
-        // Create Drawcall object drawing the GizmoDraw in the rendering context
-        void allocateDrawcallObject(
-            const graphics::DevicePointer& device,
-            const graphics::ScenePointer& scene,
-            graphics::NodeGizmo& gizmo);
-        void allocateDrawcallObject(
-            const graphics::DevicePointer& device,
-            const graphics::ScenePointer& scene,
-            graphics::ItemGizmo& gizmo);
-        void allocateDrawcallObject(
-            const graphics::DevicePointer& device,
-            const graphics::ScenePointer& scene,
-            graphics::CameraGizmo& gizmo);
+        NodeGizmo createNodeGizmo(const DevicePointer& device);
+        ItemGizmo createItemGizmo(const DevicePointer& device, const ScenePointer& scene);
 
         // Read / write shared uniforms
         const GizmoDrawUniforms& getUniforms() const { return (*_sharedUniforms); }
@@ -98,16 +83,20 @@ namespace graphics {
 
     protected:
         GizmoDrawUniformsPointer _sharedUniforms;
-        graphics::PipelineStatePointer _nodePipeline;
-        graphics::PipelineStatePointer _itemPipeline;
-        graphics::PipelineStatePointer _cameraPipeline;
+        PipelineStatePointer _nodePipeline;
+        PipelineStatePointer _itemPipeline;
+
+        DescriptorSetPointer _descriptorSet;
+
+        // Create Drawcall object drawing the GizmoDraw in the rendering context
+        void allocateDrawcallObject( const DevicePointer& device, NodeGizmo& gizmo);
+        void allocateDrawcallObject( const DevicePointer& device, const ScenePointer& scene, ItemGizmo& gizmo);
     };
     using GizmoDrawFactoryPointer = std::shared_ptr< GizmoDrawFactory>;
 
 
-    class VISUALIZATION_API NodeGizmo {
+    struct VISUALIZATION_API NodeGizmo {
     public:
-        void swapUniforms(const GizmoDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
         const GizmoDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
         core::aabox3 getBound() const { return core::aabox3(); }
@@ -120,10 +109,8 @@ namespace graphics {
         DrawObjectCallback _drawcall;
     };
 
-    class VISUALIZATION_API ItemGizmo {
+    struct VISUALIZATION_API ItemGizmo {
     public:
-
-        void swapUniforms(const GizmoDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
         const GizmoDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
         core::aabox3 getBound() const { return core::aabox3(); }
@@ -136,10 +123,8 @@ namespace graphics {
         DrawObjectCallback _drawcall;
     };
 
-    class VISUALIZATION_API CameraGizmo {
+    struct VISUALIZATION_API CameraGizmo {
     public:
-
-        void swapUniforms(const GizmoDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
         const GizmoDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
         core::aabox3 getBound() const { return core::aabox3(); }
@@ -152,6 +137,6 @@ namespace graphics {
         DrawObjectCallback _drawcall;
     };
 
-    std::tuple<graphics::Item, graphics::Item> GizmoDraw_createSceneGizmos(const ScenePointer& scene, const DevicePointer& gpudevice);
+    std::tuple<Item, Item> GizmoDraw_createSceneGizmos(const ScenePointer& scene, const DevicePointer& gpudevice);
 
 } // !namespace graphics

--- a/src/graphics/drawables/HeightmapDraw.h
+++ b/src/graphics/drawables/HeightmapDraw.h
@@ -76,21 +76,11 @@ namespace graphics {
 
     class VISUALIZATION_API HeightmapDrawFactory {
     public:
-        HeightmapDrawFactory();
+        HeightmapDrawFactory(const graphics::DevicePointer& device);
         ~HeightmapDrawFactory();
 
-        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
-        void allocateGPUShared(const graphics::DevicePointer& device);
-
         // Create HeightmapDraw for a given Heightmap document
-        graphics::HeightmapDraw* createHeightmap(const graphics::DevicePointer& device, const Heightmap& heightmap);
-
-        // Create Drawcall object drawing the HeightmapDraw in the rendering context
-        void allocateDrawcallObject(
-            const graphics::DevicePointer& device,
-            const graphics::ScenePointer& scene,
-            const graphics::CameraPointer& camera,
-            graphics::HeightmapDraw& Heightmap);
+        graphics::HeightmapDraw createHeightmap(const graphics::DevicePointer& device, const Heightmap& heightmap);
 
         // Read / write shared uniforms
         const HeightmapDrawUniforms& getUniforms() const { return (*_sharedUniforms); }
@@ -102,14 +92,17 @@ namespace graphics {
 
         graphics::PipelineStatePointer _computePipeline;
 
+        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
+        void allocateGPUShared(const graphics::DevicePointer& device);
+
+        // Create Drawcall object drawing the HeightmapDraw in the rendering context
+        void allocateDrawcallObject(const graphics::DevicePointer& device, graphics::HeightmapDraw& Heightmap);
     };
     using HeightmapDrawFactoryPointer = std::shared_ptr< HeightmapDrawFactory>;
 
 
-    class VISUALIZATION_API HeightmapDraw {
+    struct VISUALIZATION_API HeightmapDraw {
     public:
-
-        void swapUniforms(const HeightmapDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
         const HeightmapDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
         core::aabox3 getBound() const { return core::aabox3(core::vec3(0.f), core::vec3(_heightmap.map_width, 2.0f, _heightmap.map_height) * 0.5f *_heightmap.map_spacing); }

--- a/src/graphics/drawables/ModelDraw.h
+++ b/src/graphics/drawables/ModelDraw.h
@@ -57,11 +57,8 @@ namespace graphics {
 
     class VISUALIZATION_API ModelDrawFactory {
     public:
-        ModelDrawFactory();
+        ModelDrawFactory(const graphics::DevicePointer& device);
         ~ModelDrawFactory();
-
-        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
-        void allocateGPUShared(const graphics::DevicePointer& device);
 
         // Create ModelDraw for a given Model document
         graphics::ModelDraw* createModel(const graphics::DevicePointer& device, const document::ModelPointer& model);
@@ -72,7 +69,6 @@ namespace graphics {
             const graphics::ScenePointer& scene,
             graphics::ModelDraw& model);
 
-        
         graphics::ItemIDs createModelParts(const graphics::NodeID root, const graphics::ScenePointer& scene, graphics::ModelDraw& model);
 
 
@@ -84,6 +80,9 @@ namespace graphics {
     protected:
         ModelDrawUniformsPointer _sharedUniforms;
         graphics::PipelineStatePointer _pipeline;
+
+        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
+        void allocateGPUShared(const graphics::DevicePointer& device);
     };
     using ModelDrawFactoryPointer = std::shared_ptr< ModelDrawFactory>;
 
@@ -143,10 +142,9 @@ namespace graphics {
     public:
         virtual ~ModelDraw() {}
 
-        void swapUniforms(const ModelDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
         const ModelDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
-        core::aabox3 getBound() const { return _bound; }
+        DrawBound getBound() const { return _bound; }
         DrawObjectCallback getDrawcall() const { return _drawcall; }
 
         // immutable buffer containing the vertices, indices, parts and materials of the model
@@ -216,9 +214,9 @@ namespace graphics {
     };
 
     
-    class VISUALIZATION_API ModelDrawPart {
+    struct VISUALIZATION_API ModelDrawPart {
     public:
-        core::aabox3 getBound() const { return _bound; }
+        DrawBound getBound() const { return _bound; }
         DrawObjectCallback getDrawcall() const { return _drawcall; }
         
         

--- a/src/graphics/drawables/ModelDrawInspector.cpp
+++ b/src/graphics/drawables/ModelDrawInspector.cpp
@@ -69,12 +69,11 @@
 namespace graphics
 {
 
-    ModelDrawInspectorFactory::ModelDrawInspectorFactory() :
+    ModelDrawInspectorFactory::ModelDrawInspectorFactory(const graphics::DevicePointer& device) :
         _sharedUniforms(std::make_shared<ModelDrawInspectorUniforms>()) {
-
+        allocateGPUShared(device);
     }
     ModelDrawInspectorFactory::~ModelDrawInspectorFactory() {
-
     }
 
     // Custom data uniforms
@@ -618,8 +617,8 @@ namespace graphics
                             args.batch->clear(uvmeshFramebuffer, { 0, 0, 0, 0 });
 
                             core::vec4 viewport(0, 0, uvmeshFramebuffer->width(), uvmeshFramebuffer->height());
-                            args.batch->setViewport(viewport);
-                            args.batch->setScissor(viewport);
+                            args.batch->pushViewport(viewport);
+                            args.batch->pushScissor(viewport);
 
                             // Draw faces of the mesh in the edge map
                             args.batch->bindPipeline(pipeline_uvmesh_face);
@@ -659,7 +658,8 @@ namespace graphics
 
 
                             params->makeUVMeshMap = false;
-
+                            args.batch->popViewport();
+                            args.batch->popScissor();
                         }
 
                         if (first) {
@@ -696,8 +696,6 @@ namespace graphics
                         // in uv space mode, draw uvspace inspect quad
                         if (params->renderUVSpace) {
                             args.batch->bindPipeline(pipeline_draw_uvspace);
-                            args.batch->setViewport(args.camera->getViewportRect());
-                            args.batch->setScissor(args.camera->getViewportRect());
 
                             args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, args.viewPassDescriptorSet);
                             args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, descriptorSet_draw);
@@ -711,8 +709,6 @@ namespace graphics
 
                         if (params->renderConnectivity && (params->inspectedTriangle > -1)) {
                             args.batch->bindPipeline(pipeline_draw_connectivity);
-                            args.batch->setViewport(args.camera->getViewportRect());
-                            args.batch->setScissor(args.camera->getViewportRect());
 
                             args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, args.viewPassDescriptorSet);
                             args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, descriptorSet_draw);
@@ -730,8 +726,6 @@ namespace graphics
 
                         if (params->renderKernelSamples && (params->inspectedTexelX > -1) && (params->inspectedTexelY > -1)) {
                             args.batch->bindPipeline(pipeline_draw_kernelSamples);
-                            args.batch->setViewport(args.camera->getViewportRect());
-                            args.batch->setScissor(args.camera->getViewportRect());
 
                             args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, args.viewPassDescriptorSet);
                             args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, descriptorSet_draw);
@@ -761,8 +755,6 @@ namespace graphics
                     // this all works because the main texture is populated in the very first drawcall on the first call
 
                     args.batch->bindPipeline(pipeline_draw_mesh);
-                    args.batch->setViewport(args.camera->getViewportRect());
-                    args.batch->setScissor(args.camera->getViewportRect());
 
                     args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, args.viewPassDescriptorSet);
                     args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, descriptorSet_draw);
@@ -815,8 +807,6 @@ namespace graphics
 
                     if (params->renderWireframe || params->renderUVEdgeLines) {
                         args.batch->bindPipeline(pipeline_draw_edges);
-                        args.batch->setViewport(args.camera->getViewportRect());
-                        args.batch->setScissor(args.camera->getViewportRect());
 
                         args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, args.viewPassDescriptorSet);
                         args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, descriptorSet_draw);
@@ -841,8 +831,6 @@ namespace graphics
                     // draw the cloud point of samples from the uv mesh
                     if (params->renderUVMeshPoints) {
                         args.batch->bindPipeline(pipeline_draw_uvmesh_point);
-                        args.batch->setViewport(args.camera->getViewportRect());
-                        args.batch->setScissor(args.camera->getViewportRect());
 
                         args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, args.viewPassDescriptorSet);
                         args.batch->bindDescriptorSet(graphics::PipelineType::GRAPHICS, descriptorSet_draw);

--- a/src/graphics/drawables/ModelDrawInspector.h
+++ b/src/graphics/drawables/ModelDrawInspector.h
@@ -162,11 +162,8 @@ namespace graphics {
 
     class VISUALIZATION_API ModelDrawInspectorFactory {
     public:
-        ModelDrawInspectorFactory();
+        ModelDrawInspectorFactory(const graphics::DevicePointer& device);
         ~ModelDrawInspectorFactory();
-
-        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
-        void allocateGPUShared(const graphics::DevicePointer& device);
 
         // Create ModelDraw for a given Model document
         graphics::ModelDrawInspector* createModel(const graphics::DevicePointer& device, const document::ModelPointer& model, const ModelDraw* draw);
@@ -175,9 +172,8 @@ namespace graphics {
         void allocateDrawcallObject(
             const graphics::DevicePointer& device,
             const graphics::ScenePointer& scene,
-            graphics::ModelDrawInspector& model);
+            graphics::ModelDrawInspector& model); 
 
-        
         graphics::ItemIDs createModelParts(const graphics::NodeID root, const graphics::ScenePointer& scene, graphics::ModelDrawInspector& model);
 
 
@@ -205,14 +201,16 @@ namespace graphics {
 
         graphics::PipelineStatePointer _pipeline_compute_imageSpaceBlur;
         graphics::PipelineStatePointer _pipeline_compute_meshSpaceBlur;
+
+
+        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
+        void allocateGPUShared(const graphics::DevicePointer& device);
     };
     using ModelDrawInspectorFactoryPointer = std::shared_ptr< ModelDrawInspectorFactory>;
 
 
     class VISUALIZATION_API ModelDrawInspector : public ModelDraw {
     public:
-
-        void swapUniforms(const ModelDrawInspectorUniformsPointer& uniforms) { _uniforms = uniforms; }
         const ModelDrawInspectorUniformsPointer& getUniforms() const { return _uniforms; }
         
         // PRE pass DrawbleID
@@ -241,7 +239,7 @@ namespace graphics {
     };
 
     
-    class VISUALIZATION_API ModelDrawInspectorPart {
+    struct VISUALIZATION_API ModelDrawInspectorPart {
     public:
         core::aabox3 getBound() const { return _bound; }
         DrawObjectCallback getDrawcall() const { return _drawcall; }

--- a/src/graphics/drawables/PointcloudDraw.h
+++ b/src/graphics/drawables/PointcloudDraw.h
@@ -78,18 +78,12 @@ namespace graphics {
 
     class VISUALIZATION_API PointCloudDrawFactory {
     public:
-        PointCloudDrawFactory();
+        PointCloudDrawFactory(const graphics::DevicePointer& device);
         ~PointCloudDrawFactory();
 
-        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
-        void allocateGPUShared(const graphics::DevicePointer& device);
-
         // Create PointCloudDraw for a given PointCloud document, building the gpu vertex buffer
-        graphics::PointCloudDraw* createPointCloudDraw(const graphics::DevicePointer& device, const document::PointCloudPointer& pointcloud);
-
-        // Create Drawcall object drawing the PointCloudDraw in the rendering context
-        void allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::ScenePointer& scene, graphics::PointCloudDraw& pointcloudDraw);
-    
+        graphics::PointCloudDraw createPointCloudDraw(const graphics::DevicePointer& device, const document::PointCloudPointer& pointcloud);
+ 
         // Read / write shared uniforms
         const PointCloudDrawUniforms& getUniforms() const { return (*_sharedUniforms); }
         PointCloudDrawUniforms& editUniforms() { return (*_sharedUniforms); }
@@ -97,16 +91,18 @@ namespace graphics {
     protected:
         PointCloudDrawUniformsPointer _sharedUniforms;
         graphics::PipelineStatePointer _pipeline;
+
+        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
+        void allocateGPUShared(const graphics::DevicePointer& device);
+
+        // Create Drawcall object drawing the PointCloudDraw in the rendering context
+        void allocateDrawcallObject(const graphics::DevicePointer& device, graphics::PointCloudDraw& pointcloudDraw);
     };
     using PointCloudDrawFactoryPointer = std::shared_ptr< PointCloudDrawFactory>;
     
 
-    class VISUALIZATION_API PointCloudDraw {
+    struct VISUALIZATION_API PointCloudDraw {
     public:
-        PointCloudDraw();
-        ~PointCloudDraw();
-
-        void swapUniforms(const PointCloudDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
         const PointCloudDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
         graphics::BufferPointer getVertexBuffer() const { return _vertexBuffer; }

--- a/src/graphics/drawables/PostSceneDraw.h
+++ b/src/graphics/drawables/PostSceneDraw.h
@@ -51,20 +51,12 @@ namespace graphics {
 
     class VISUALIZATION_API PostSceneDrawFactory {
     public:
-        PostSceneDrawFactory();
+        PostSceneDrawFactory(const graphics::DevicePointer& device);
         ~PostSceneDrawFactory();
 
-        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
-        void allocateGPUShared(const graphics::DevicePointer& device);
-
         // Create PostSceneDraw
-        graphics::PostSceneDraw* createDraw(const graphics::DevicePointer& device, const graphics::GeometryPointer& geometry);
+        graphics::PostSceneDraw createDraw(const graphics::DevicePointer& device, const graphics::GeometryPointer& geometry);
 
-        // Create Drawcall object drawing the PostSceneDraw in the rendering context
-        void allocateDrawcallObject(
-            const graphics::DevicePointer& device,
-            const graphics::ScenePointer& scene,
-            graphics::PostSceneDraw& primitive);
 
         // Read / write shared uniforms
         const PostSceneDrawUniforms& getUniforms() const { return (*_sharedUniforms); }
@@ -74,14 +66,20 @@ namespace graphics {
     protected:
         PostSceneDrawUniformsPointer _sharedUniforms;
         graphics::PipelineStatePointer _primitivePipeline;
+
+        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
+        void allocateGPUShared(const graphics::DevicePointer& device);
+
+        // Create Drawcall object drawing the PostSceneDraw in the rendering context
+        void allocateDrawcallObject(
+            const graphics::DevicePointer& device,
+            graphics::PostSceneDraw& primitive);
     };
     using PostSceneDrawFactoryPointer = std::shared_ptr< PostSceneDrawFactory>;
 
 
-    class VISUALIZATION_API PostSceneDraw {
+    struct VISUALIZATION_API PostSceneDraw {
     public:
-
-        void swapUniforms(const PostSceneDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
         const PostSceneDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
         core::vec3 _size{ 1.0f };

--- a/src/graphics/drawables/SkyDraw.h
+++ b/src/graphics/drawables/SkyDraw.h
@@ -36,18 +36,8 @@
 #include <gpu/Query.h>
 
 namespace graphics {
-    class Device;
-    using DevicePointer = std::shared_ptr<Device>;
-    class Camera;
-    using CameraPointer = std::shared_ptr<Camera>;
-    class Buffer;
-    using BufferPointer = std::shared_ptr<Buffer>;
-    class PipelineState;
-    using PipelineStatePointer = std::shared_ptr<PipelineState>;
 
     class SkyDraw;
-
-
 
     struct VISUALIZATION_API SkyDrawUniforms {
         SkyPointer _sky;
@@ -57,20 +47,11 @@ namespace graphics {
 
     class VISUALIZATION_API SkyDrawFactory {
     public:
-        SkyDrawFactory();
+        SkyDrawFactory(const graphics::DevicePointer& device);
         ~SkyDrawFactory();
 
-        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
-        void allocateGPUShared(const graphics::DevicePointer& device);
-
         // Create SkyDraw
-        graphics::SkyDraw* createDraw(const graphics::DevicePointer& device);
-
-        // Create Drawcall object drawing the SkyDraw in the rendering context
-        void allocateDrawcallObject(
-            const graphics::DevicePointer& device,
-            const graphics::ScenePointer& scene,
-            graphics::SkyDraw& primitive);
+        graphics::SkyDraw createDraw(const graphics::DevicePointer& device);
 
         // Read / write shared uniforms
         const SkyDrawUniforms& getUniforms() const { return (*_sharedUniforms); }
@@ -82,14 +63,21 @@ namespace graphics {
 
         graphics::PipelineStatePointer _skymapPipeline;
         graphics::PipelineStatePointer _diffuseSkymapPipeline[2];
+
+        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
+        void allocateGPUShared(const graphics::DevicePointer& device);
+
+        // Create Drawcall object drawing the SkyDraw in the rendering context
+        void allocateDrawcallObject(
+            const graphics::DevicePointer& device,
+            graphics::SkyDraw& primitive);
+
     };
     using SkyDrawFactoryPointer = std::shared_ptr< SkyDrawFactory>;
 
 
-    class VISUALIZATION_API SkyDraw {
+    struct VISUALIZATION_API SkyDraw {
     public:
-
-        void swapUniforms(const SkyDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
         const SkyDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
         core::vec3 _size{ 1.0f };

--- a/src/graphics/drawables/TriangleSoupDraw.h
+++ b/src/graphics/drawables/TriangleSoupDraw.h
@@ -56,17 +56,13 @@ namespace graphics {
 
     class VISUALIZATION_API TriangleSoupDrawFactory {
     public:
-        TriangleSoupDrawFactory();
+        TriangleSoupDrawFactory(const graphics::DevicePointer& device);
         ~TriangleSoupDrawFactory();
 
-        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
-        void allocateGPUShared(const graphics::DevicePointer& device);
 
-        // Create TriangleSoupDraw for a given TriangleSoup document, building the gpu vertex buffer
-        graphics::TriangleSoupDraw* createTriangleSoupDraw(const graphics::DevicePointer& device, const document::TriangleSoupPointer& pointcloud);
+        // Create TriangleSoupDraw for a given TriangleSoup document, building the gpu resource
+        graphics::TriangleSoupDraw createTriangleSoupDraw(const graphics::DevicePointer& device, const document::TriangleSoupPointer& pointcloud);
 
-        // Create Drawcall object drawing the TriangleSoupDraw in the rendering context
-        void allocateDrawcallObject(const graphics::DevicePointer& device, const graphics::ScenePointer& scene, graphics::TriangleSoupDraw& pointcloudDraw);
 
         // Read / write shared uniforms
         const TriangleSoupDrawUniforms& getUniforms() const { return (*_sharedUniforms); }
@@ -75,20 +71,20 @@ namespace graphics {
     protected:
         TriangleSoupDrawUniformsPointer _sharedUniforms;
         graphics::PipelineStatePointer _pipeline;
+
+        // Cache the shaders and pipeline to share them accross multiple instances of drawcalls
+        void allocateGPUShared(const graphics::DevicePointer& device);
+
+        // Create Drawcall object drawing the TriangleSoupDraw in the rendering context
+        void allocateDrawcallObject(const graphics::DevicePointer& device, graphics::TriangleSoupDraw& pointcloudDraw);
+
     };
     using TriangleSoupDrawFactoryPointer = std::shared_ptr< TriangleSoupDrawFactory>;
 
 
-    /*
-    const pico::DrawcallObjectPointer& getDraw(const TriangleSoupDraw& x) {
-        return x.getDraw();
-    }*/
-    class VISUALIZATION_API TriangleSoupDraw {
-    public:
-        TriangleSoupDraw();
-        ~TriangleSoupDraw();
 
-        void swapUniforms(const TriangleSoupDrawUniformsPointer& uniforms) { _uniforms = uniforms; }
+    struct VISUALIZATION_API TriangleSoupDraw {
+    public:
         const TriangleSoupDrawUniformsPointer& getUniforms() const { return _uniforms; }
 
         graphics::BufferPointer getVertexBuffer() const { return _vertexBuffer; }

--- a/src/graphics/gpu/Batch.cpp
+++ b/src/graphics/gpu/Batch.cpp
@@ -62,9 +62,6 @@ void Batch::resourceBarrierRW(
 void Batch::resourceBarrierRW(
     ResourceBarrierFlag flag, const TexturePointer& texture, uint32_t subresource) {}
 
-void Batch::setViewport(const core::vec4& viewport) {}
-void Batch::setScissor(const core::vec4& scissor) {}
-
 void Batch::bindFramebuffer(const FramebufferPointer& framebuffer) {}
 
 void Batch::bindRootDescriptorLayout(PipelineType type, const RootDescriptorLayoutPointer& rootLayout) {}

--- a/src/graphics/gpu/Batch.h
+++ b/src/graphics/gpu/Batch.h
@@ -72,8 +72,41 @@ namespace graphics {
         virtual void resourceBarrierRW(
             ResourceBarrierFlag flag, const TexturePointer& texture, uint32_t subresource);
 
-        virtual void setViewport(const core::vec4& viewport);
-        virtual void setScissor(const core::vec4& scissor);
+        // Viewport and scissor provide a stack management system
+        
+        inline virtual void setViewport(const core::vec4& viewport) final {
+            _viewportStack.back() = viewport;
+            _setViewport(viewport);
+        }
+
+        inline virtual void pushViewport(const core::vec4& viewport) final {
+            _viewportStack.emplace_back(viewport);
+            _setViewport(viewport);
+        }
+        inline virtual void popViewport() final {
+            _viewportStack.pop_back();
+            _setViewport(_viewportStack.back());
+        }
+
+        inline virtual void setScissor(const core::vec4& scissor) final {
+            _scissorStack.back() = scissor;
+            _setScissor(scissor);
+        }
+
+        inline virtual void pushScissor(const core::vec4& scissor) final {
+            _scissorStack.emplace_back(scissor);
+            _setScissor(scissor);
+        }
+        inline virtual void popScissor() final {
+            _scissorStack.pop_back();
+            _setScissor(_scissorStack.back());
+        }
+
+    protected:
+        virtual void _setViewport(const core::vec4& viewport) {}
+        virtual void _setScissor(const core::vec4& scissor) {}
+
+    public:
 
         virtual void bindFramebuffer(const FramebufferPointer& framebuffer);
 
@@ -120,5 +153,8 @@ namespace graphics {
             uint16_t depth = 1;
         };
         virtual void dispatchRays(const DispatchRaysArgs& args);
+
+        std::vector< core::vec4 > _viewportStack = std::vector< core::vec4 >(1); // The stack of viewports used by the set push pop viewport system
+        std::vector< core::vec4 > _scissorStack = std::vector< core::vec4 >(1); // The stack of scissors used by the set push pop scissor system
     };
 }

--- a/src/graphics/render/Item.cpp
+++ b/src/graphics/render/Item.cpp
@@ -114,7 +114,8 @@ namespace graphics {
         auto itemCount = numAllocatedItems();
 
         // Pre allocate the result with the expected size
-        ItemInfos itemInfos(itemCount, ItemInfo());
+        // I wish we could avoid initializing all the N  new elements here, ... std::vector in c++30 ?
+        ItemInfos itemInfos(itemCount);
 
         // copy
         memcpy(itemInfos.data(), begin_info, itemCount * sizeof(ItemInfo));
@@ -126,7 +127,7 @@ namespace graphics {
     core::aabox3 ItemStore::fetchWorldBound(ItemID id) const {
         auto [info, l] = _itemInfos.read(id);
         if ((info->_nodeID != INVALID_NODE_ID) && (info->_drawID != INVALID_DRAW_ID)) {
-            return core::aabox_transformFrom(_scene->_nodes.getNodeTransform(info->_nodeID).world, _scene->_drawables.getBound(info->_drawID));
+            return core::aabox_transformFrom(_scene->_nodes.getNodeTransform(info->_nodeID).world, _scene->_drawables.getDrawBound(info->_drawID));
         } else {
             return core::aabox3();
         }

--- a/src/graphics/render/Scene.h
+++ b/src/graphics/render/Scene.h
@@ -89,10 +89,9 @@ namespace graphics {
 
         // Draws
         DrawStore _drawables;
-        Draw getDraw(DrawID DrawID) const;
         template <typename T>
-        Draw createDraw(T& x) {
-            return _drawables.createDraw(x);
+        Draw createDraw(T x) {
+            return _drawables.createDraw(std::move(x));
         }
 
         // Cameras

--- a/src/graphics/render/Viewport.cpp
+++ b/src/graphics/render/Viewport.cpp
@@ -148,16 +148,16 @@ void Viewport::renderScene(RenderArgs& args) {
     for (int i = 1; i < itemInfos.size(); i++) {
         const auto& info = itemInfos[i];
         if (info.isValid() && info.isVisible() && info.isDraw()) {
-            auto drawcall = _scene->_drawables.getDrawcall(info._drawID);
-            drawcall(info._nodeID, args);
+        //    auto drawcall = _scene->_drawables.getDrawcall(info._drawID);
+            _scene->_drawables.getDrawcall(info._drawID)(info._nodeID, args);
         }
     }
 
     if (itemInfos.size() > 0) {
         const auto& info = itemInfos[0];
         if (info.isValid() && info.isVisible() && info.isDraw()) {
-            auto drawcall = _scene->_drawables.getDrawcall(info._drawID);
-            drawcall(info._nodeID, args);
+   //         auto drawcall = _scene->_drawables.getDrawcall(info._drawID);
+            _scene->_drawables.getDrawcall(info._drawID)(info._nodeID, args);
         }
     }
 }

--- a/test/pico_eye/pico_eye.cpp
+++ b/test/pico_eye/pico_eye.cpp
@@ -97,8 +97,7 @@ AppState state;
 graphics::NodeIDs generateModel(document::ModelPointer lmodel, graphics::DevicePointer& gpuDevice, graphics::ScenePointer& scene, graphics::NodeID nodeRoot) {
 
     if (!state._modelDrawFactory) {
-        state._modelDrawFactory = std::make_shared<graphics::ModelDrawFactory>();
-        state._modelDrawFactory->allocateGPUShared(gpuDevice);
+        state._modelDrawFactory = std::make_shared<graphics::ModelDrawFactory>(gpuDevice);
         state._modelDrawParams = state._modelDrawFactory->getUniformsPtr();
     }
 
@@ -225,8 +224,7 @@ int main(int argc, char *argv[])
     auto viewport = std::make_shared<graphics::Viewport>(viewportInit);
 
     // a sky draw to draw the sky
-    auto skyDraw = state.scene->createDraw(*skyDrawFactory->createDraw(gpuDevice));
-    skyDrawFactory->allocateDrawcallObject(gpuDevice, state.scene, skyDraw.as<graphics::SkyDraw>());
+    auto skyDraw = state.scene->createDraw(skyDrawFactory->createDraw(gpuDevice));;
     auto skyitem = state.scene->createItem(graphics::Node::null, skyDraw);
     skyitem.setVisible(true);
 

--- a/test/pico_model/pico_model.cpp
+++ b/test/pico_model/pico_model.cpp
@@ -123,21 +123,17 @@ graphics::NodeIDs generateModel(graphics::DevicePointer& gpuDevice, graphics::Sc
     lmodel = document::model::Model::createFromGLTF(modelFile);
 
     if (!state._modelDrawFactory) {
-        state._modelDrawFactory = std::make_shared<graphics::ModelDrawFactory>();
-        state._modelDrawFactory->allocateGPUShared(gpuDevice);
+        state._modelDrawFactory = std::make_shared<graphics::ModelDrawFactory>(gpuDevice);
     }
 
     auto modelDrawPtr = state._modelDrawFactory->createModel(gpuDevice, lmodel);
-    state._modelDrawFactory->allocateDrawcallObject(gpuDevice, scene, *modelDrawPtr);
-
     auto modelDraw = scene->createDraw(*modelDrawPtr);
 
     graphics::ItemIDs modelItemIDs;
 
     if (withInspector) {
         if (!state._modelDrawInspectorFactory) {
-            state._modelDrawInspectorFactory = std::make_shared<graphics::ModelDrawInspectorFactory>();
-            state._modelDrawInspectorFactory->allocateGPUShared(gpuDevice);
+            state._modelDrawInspectorFactory = std::make_shared<graphics::ModelDrawInspectorFactory>(gpuDevice);
             state.params = state._modelDrawInspectorFactory->getUniformsPtr();
             state.params->setFilterKernelTechnique(graphics::ModelDrawInspectorUniforms::FKT_IMAGE_SPACE);
         }

--- a/test/pico_ocean/ocean.h
+++ b/test/pico_ocean/ocean.h
@@ -293,7 +293,7 @@ public:
 ocean::Ocean* locean;
 std::vector<graphics::NodeID> prim_nodes;
 graphics::ScenePointer lscene;
-graphics::Draw heightmap_drawable;
+graphics::Draw heightmap_draw;
 
 void generateSpectra(uint32_t map_res, float map_spacing, uint32_t mesh_res, float mesh_spacing, graphics::DevicePointer& gpuDevice, graphics::ScenePointer& scene, graphics::CameraPointer& camera, graphics::Node& root) {
 
@@ -303,37 +303,20 @@ void generateSpectra(uint32_t map_res, float map_spacing, uint32_t mesh_res, flo
     lscene = scene;
 
     // A Heightmap draw factory
-    auto HeightmapDrawFactory = std::make_shared<graphics::HeightmapDrawFactory>();
-    HeightmapDrawFactory->allocateGPUShared(gpuDevice);
+    auto HeightmapDrawFactory = std::make_shared<graphics::HeightmapDrawFactory>(gpuDevice);
 
     // a Heightmap
-    heightmap_drawable = scene->createDraw(*HeightmapDrawFactory->createHeightmap(gpuDevice, {
+    heightmap_draw = scene->createDraw(HeightmapDrawFactory->createHeightmap(gpuDevice, {
          map_res, map_res, map_spacing,
          mesh_res, mesh_res, mesh_spacing
        }));
-    HeightmapDrawFactory->allocateDrawcallObject(gpuDevice, scene, camera, heightmap_drawable.as<graphics::HeightmapDraw>());
 
-
-
-    scene->createItem(root, heightmap_drawable);
+    scene->createItem(root, heightmap_draw);
 }
 
 void updateHeights(float t) {
 
     locean->UpdateHeights(t);
-
-    graphics::HeightmapDraw& heightmap =  heightmap_drawable.as<graphics::HeightmapDraw>();
-
-    auto buffer = heightmap.getHeightBuffer();
-    auto desc = heightmap.getDesc();
-
-    auto numElements = desc.getMapNumElements();
-
- //   memcpy(buffer->_cpuMappedAddress, locean->_heights.data(), locean->_heights.size() * sizeof(float));
-
-
-    
-
 
     for (int i = 0; i < prim_nodes.size(); i++) {
 

--- a/test/pico_terrain/pico_terrain.cpp
+++ b/test/pico_terrain/pico_terrain.cpp
@@ -82,23 +82,19 @@ void generateTerrain(uint32_t map_res, float map_spacing, graphics::DevicePointe
 
 
       // A Heightmap draw factory
-    auto HeightmapDrawFactory = std::make_shared<graphics::HeightmapDrawFactory>();
-    HeightmapDrawFactory->allocateGPUShared(gpuDevice);
+    auto HeightmapDrawFactory = std::make_shared<graphics::HeightmapDrawFactory>(gpuDevice);
 
-    // a Heightmap
-    graphics::Draw heightmap_drawable;
-
+    // a Heightmap draw
     map_res = lterrain->_resolution;
     map_spacing = lterrain->_spacing;
-
-    heightmap_drawable = scene->createDraw(*HeightmapDrawFactory->createHeightmap(gpuDevice, {
+    auto heightmap_draw = scene->createDraw(HeightmapDrawFactory->createHeightmap(gpuDevice, {
          map_res, map_res, map_spacing,
          map_res, map_res, map_spacing,
          lterrain->_heights
         }));
-    HeightmapDrawFactory->allocateDrawcallObject(gpuDevice, scene, camera, heightmap_drawable.as<graphics::HeightmapDraw>());
 
-    scene->createItem(root, heightmap_drawable);
+    // In an item
+    scene->createItem(root, heightmap_draw);
 }
 
 //--------------------------------------------------------------------------------------
@@ -136,11 +132,12 @@ int main(int argc, char *argv[])
     // Some nodes to layout the scene and animate objects
     auto node0 = scene->createNode(core::mat4x3(), -1);
 
+    // Create gizmos to draw the node transform and item tree
+    auto [gznode_tree, gzitem_tree] = graphics::GizmoDraw_createSceneGizmos(scene, gpuDevice);
+
     auto terrain_resolution = 512;
     generateTerrain(terrain_resolution, 1.0f, gpuDevice, scene, camera, node0);
 
-    // Create gizmos to draw the node transform and item tree
-    auto [gznode_tree, gzitem_tree] = graphics::GizmoDraw_createSceneGizmos(scene, gpuDevice);
 
     // Bounds
     scene->updateBounds();


### PR DESCRIPTION
Iterating on what Draw struct is and the real need for a pointed T _data
it is not ideal right now, T _data passed to the drawcall is NOT the same as the one hold in the Draw::Model<T>
but we will get there eventually.

Reviewed all the DrawFactory classes to do the allocation of gpu object while creating the Draw object per VALUE

did a pass of optimization with Superluminal
 in the batch i added a cache for the pipeline and the descriptor set and introduced a push pop approach for the viewport and scissor and i could shave a lot in the Pico 4 with 10000 PrimitiveItems yeah!