### PR TITLE
Creating a dummy buffer for animation

### DIFF
--- a/src/graphics/drawables/ModelDraw.cpp
+++ b/src/graphics/drawables/ModelDraw.cpp
@@ -717,6 +717,12 @@ namespace graphics
                     modelDraw->_skinJointBindings.emplace_back(binding);
                 }
             }
+
+            // add a dummy joint binding to have a valid buffer even if not used
+            if (modelDraw->_skinJointBindings.empty())
+            {
+                modelDraw->_skinJointBindings.emplace_back(ModelSkinJointBinding());
+            }
             // skin buffer
             BufferInit skinBufferInit;
             int32_t skinJointElementPerStruct = 4;


### PR DESCRIPTION
always add a dummy skin joint to have a valid buffer