### PR TITLE
Fix sky rendering, compute dispatch, and sRGB gamma on Metal

### DIFF
--- a/ext/scribe/src/MslCompiler.cpp
+++ b/ext/scribe/src/MslCompiler.cpp
@@ -15,6 +15,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <unistd.h>
 
 // ---------------------------------------------------------------------------
@@ -110,6 +111,7 @@ MslResult compileHlslToMsl(
     int ssboBindingShift)
 {
     MslResult result;
+    std::string combinedMsl;
 
     for (auto& entry : entryPoints) {
         std::vector<uint32_t> spirv;
@@ -129,11 +131,65 @@ MslResult compileHlslToMsl(
         }
 
         result.success = true;
-        result.mslSource = msl;
-        // Use only the first successful entry point — spirv-cross renames all
-        // entries to 'main0', so concatenating multiple causes redefinitions.
-        break;
+
+        if (combinedMsl.empty()) {
+            // First entry: keep the full MSL (structs, helpers, entry function)
+            combinedMsl = msl;
+        } else {
+            // Subsequent entries: find the kernel/vertex/fragment function and append.
+            // For compute shaders, spirv-cross preserves entry names (main_makeSkymap etc.)
+            // so there's no duplicate 'main0' issue. For vert/frag, spirv-cross renames
+            // all entries to 'main0' — skip subsequent entries to avoid redefinition.
+            if (stage == "comp") {
+                // For compute: each entry has a unique name (not renamed to main0).
+                // Strip duplicate struct definitions but keep unique helpers
+                // (spvUnsafeArray, spvTexelBufferCoord, etc.) that may not exist
+                // in the first entry's MSL.
+                combinedMsl += "\n// --- entry point: " + entry + " ---\n";
+
+                // Process line by line: skip struct blocks, keep everything else
+                std::istringstream stream(msl);
+                std::string line;
+                bool inStruct = false;
+                int braceDepth = 0;
+                while (std::getline(stream, line)) {
+                    // Detect struct definitions (but not template struct like spvUnsafeArray)
+                    if (!inStruct && line.find("struct ") == 0) {
+                        // Check if this struct is already defined in combinedMsl
+                        if (combinedMsl.find(line) != std::string::npos) {
+                            inStruct = true;
+                            braceDepth = 0;
+                            for (char c : line) {
+                                if (c == '{') braceDepth++;
+                                if (c == '}') braceDepth--;
+                            }
+                            continue;
+                        }
+                    }
+                    if (inStruct) {
+                        for (char c : line) {
+                            if (c == '{') braceDepth++;
+                            if (c == '}') braceDepth--;
+                        }
+                        if (braceDepth <= 0) inStruct = false;
+                        continue;
+                    }
+                    // Skip #pragma and #include that are duplicates
+                    if (line.find("#pragma") == 0 || line.find("#include") == 0) {
+                        if (combinedMsl.find(line) != std::string::npos) continue;
+                    }
+                    // Skip "using namespace metal;" duplicate
+                    if (line.find("using namespace metal;") != std::string::npos) {
+                        if (combinedMsl.find("using namespace metal;") != std::string::npos) continue;
+                    }
+                    combinedMsl += line + "\n";
+                }
+            }
+            // For vert/frag: skip (spirv-cross renames all to main0 → redefinition)
+        }
     }
+
+    result.mslSource = combinedMsl;
 
     return result;
 }

--- a/src/graphics/drawables/SkyDraw.cpp
+++ b/src/graphics/drawables/SkyDraw.cpp
@@ -161,7 +161,9 @@ namespace graphics
                // Let's describe the Compute pipeline Descriptors layout
                graphics::ComputePipelineStateInit skymap_pipelineInit{
                    skymap_compShader,
-                   skymap_descriptorLayout
+                   skymap_descriptorLayout,
+                   {}, // watch_name
+                   8, 8, 1 // [numthreads(8,8,1)]
                };
 
                _skymapPipeline = device->createComputePipelineState(skymap_pipelineInit);
@@ -193,7 +195,9 @@ namespace graphics
             // Let's describe the Compute pipeline Descriptors layout
             graphics::ComputePipelineStateInit diffuse_skymap_pipelineInit{
                 diffuse_skymap_compShader,
-                diffuse_skymap_descriptorLayout
+                diffuse_skymap_descriptorLayout,
+                {}, // watch_name
+                64, 1, 1 // [numthreads(THREAD_GROUP_DIM, 1, 1)]
             };
 
             _diffuseSkymapPipeline[0] = device->createComputePipelineState(diffuse_skymap_pipelineInit);
@@ -204,7 +208,9 @@ namespace graphics
             // Let's describe the Compute pipeline Descriptors layout
             graphics::ComputePipelineStateInit diffuse_skymap_next_pipelineInit{
                 diffuse_skymap_next_compShader,
-                diffuse_skymap_descriptorLayout
+                diffuse_skymap_descriptorLayout,
+                {}, // watch_name
+                64, 1, 1 // [numthreads(THREAD_GROUP_DIM, 1, 1)]
             };
             _diffuseSkymapPipeline[1] = device->createComputePipelineState(diffuse_skymap_next_pipelineInit);
         }

--- a/src/graphics/gpu/Device.cpp
+++ b/src/graphics/gpu/Device.cpp
@@ -40,13 +40,8 @@ namespace graphics {
 
 
 graphics::PixelFormat graphics::defaultColorBufferFormat() {
-#ifdef __APPLE__
-    // R8G8B8A8_UNORM maps to MTLPixelFormatBGRA8Unorm in the Metal format table,
-    // which is the native CAMetalLayer format on macOS.
-    return graphics::PixelFormat::R8G8B8A8_UNORM;
-#else
+    // sRGB format — the GPU handles linear→sRGB conversion on write
     return graphics::PixelFormat::R8G8B8A8_UNORM_SRGB;
-#endif
 }
 
 

--- a/src/graphics/gpu/Pipeline.h
+++ b/src/graphics/gpu/Pipeline.h
@@ -55,8 +55,13 @@ namespace graphics {
     struct VISUALIZATION_API ComputePipelineStateInit {
         ShaderPointer program;
         RootDescriptorLayoutPointer rootDescriptorLayout;
-        
+
         std::string watch_name;
+
+        // Thread group dimensions from [numthreads(X,Y,Z)] — needed for Metal dispatch
+        uint32_t threadGroupX { 1 };
+        uint32_t threadGroupY { 1 };
+        uint32_t threadGroupZ { 1 };
     };
 
     struct VISUALIZATION_API RaytracingPipelineStateInit {

--- a/src/graphics/metal/MetalBackend.h
+++ b/src/graphics/metal/MetalBackend.h
@@ -150,6 +150,7 @@ public:
     id<MTLComputePipelineState> _computePipeline { nil };
     id<MTLDepthStencilState>    _depthStencilState { nil };
     MTLPrimitiveType            _primitiveType { MTLPrimitiveTypeTriangle };
+    MTLSize                     _threadGroupSize { 1, 1, 1 };
     MTLCullMode                 _cullMode { MTLCullModeNone };
     MTLWinding                  _winding  { MTLWindingCounterClockwise };
 

--- a/src/graphics/metal/MetalBackend_Batch.mm
+++ b/src/graphics/metal/MetalBackend_Batch.mm
@@ -222,20 +222,33 @@ void MetalBatchBackend::bindPipeline(const PipelineStatePointer& pipeline) {
     auto* pso = static_cast<MetalPipelineStateBackend*>(pipeline.get());
     _currentPipeline = pso;
 
-    if (_renderEncoder) {
-        if (pso->_renderPipeline)
-            [_renderEncoder setRenderPipelineState:pso->_renderPipeline];
-        if (pso->_depthStencilState)
-            [_renderEncoder setDepthStencilState:pso->_depthStencilState];
-        else
+    if (pso->_renderPipeline) {
+        // If we were in compute mode, switch back to render
+        if (!_renderEncoder && _currentRenderPassDescriptor) {
+            _endCurrentEncoder();
+            // Restart the render pass with LoadAction::Load to preserve existing content
+            _currentRenderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionLoad;
+            if (_currentRenderPassDescriptor.depthAttachment.texture)
+                _currentRenderPassDescriptor.depthAttachment.loadAction = MTLLoadActionLoad;
+            _renderEncoder = [_commandBuffer renderCommandEncoderWithDescriptor:_currentRenderPassDescriptor];
             [_renderEncoder setDepthStencilState:_defaultDepthStencilState];
-
-        // Rasterizer settings (cached in PSO at creation time)
-        [_renderEncoder setCullMode:pso->_cullMode];
-        [_renderEncoder setFrontFacingWinding:pso->_winding];
-    } else if (_computeEncoder) {
-        if (pso->_computePipeline)
-            [_computeEncoder setComputePipelineState:pso->_computePipeline];
+        }
+        if (_renderEncoder) {
+            [_renderEncoder setRenderPipelineState:pso->_renderPipeline];
+            if (pso->_depthStencilState)
+                [_renderEncoder setDepthStencilState:pso->_depthStencilState];
+            else
+                [_renderEncoder setDepthStencilState:_defaultDepthStencilState];
+            [_renderEncoder setCullMode:pso->_cullMode];
+            [_renderEncoder setFrontFacingWinding:pso->_winding];
+        }
+    } else if (pso->_computePipeline) {
+        // Create compute encoder if needed
+        if (!_computeEncoder) {
+            _endCurrentEncoder();
+            _computeEncoder = [_commandBuffer computeCommandEncoder];
+        }
+        [_computeEncoder setComputePipelineState:pso->_computePipeline];
     }
 }
 
@@ -291,7 +304,10 @@ void MetalBatchBackend::bindDescriptorSet(PipelineType type,
         } else if (_computeEncoder) {
             switch (b.kind) {
                 case MetalBinding::Kind::Buffer:
-                    [_computeEncoder setBuffer:b.buffer offset:b.bufferOffset atIndex:b.slot];
+                    [_computeEncoder setBuffer:b.buffer offset:b.bufferOffset atIndex:slot];
+                    // Also bind texture view for Buffer<T>/RWBuffer<T>
+                    if (b.texture)
+                        [_computeEncoder setTexture:b.texture atIndex:b.slot];
                     break;
                 case MetalBinding::Kind::Texture:
                     [_computeEncoder setTexture:b.texture atIndex:b.slot];
@@ -402,9 +418,10 @@ void MetalBatchBackend::_setScissor(const core::vec4& sc) {
 // ---------------------------------------------------------------------------
 void MetalBatchBackend::dispatch(uint32_t x, uint32_t y, uint32_t z) {
     if (!_computeEncoder || !_currentPipeline || !_currentPipeline->_computePipeline) return;
-    MTLSize threads    = MTLSizeMake(x, y, z);
-    MTLSize threadSize = MTLSizeMake(1, 1, 1);
-    [_computeEncoder dispatchThreadgroups:threads threadsPerThreadgroup:threadSize];
+    MTLSize threadgroups = MTLSizeMake(x, y, z);
+    // Thread group size is baked into the compute pipeline from [numthreads(X,Y,Z)]
+    MTLSize threadsPerGroup = _currentPipeline->_threadGroupSize;
+    [_computeEncoder dispatchThreadgroups:threadgroups threadsPerThreadgroup:threadsPerGroup];
 }
 
 void MetalBatchBackend::dispatchRays(const DispatchRaysArgs&) {

--- a/src/graphics/metal/MetalBackend_Descriptor.mm
+++ b/src/graphics/metal/MetalBackend_Descriptor.mm
@@ -69,27 +69,34 @@ void MetalBackend::updateDescriptorSet(DescriptorSetPointer& descriptorSet,
                         // Also create a texture view for Buffer<T> types that
                         // spirv-cross converts to texture2d in MSL
                         auto* mbuf = static_cast<MetalBufferBackend*>(obj._buffer.get());
-                        if (mbuf->_buffer && obj._type == DescriptorType::RESOURCE_BUFFER) {
+                        if (mbuf->_buffer && (obj._type == DescriptorType::RESOURCE_BUFFER ||
+                                              obj._type == DescriptorType::RW_RESOURCE_BUFFER)) {
+                            bool isRW = (obj._type == DescriptorType::RW_RESOURCE_BUFFER);
                             // Create a texture2d view for Buffer<T> → texture2d mapping.
                             // spirv-cross converts HLSL Buffer<uint> to MSL texture2d<uint>
                             // using spvTexelBufferCoord() with width=4096 for 2D indexing.
                             // spirv-cross uses spvTexelBufferCoord(tc) = uint2(tc % 4096, tc / 4096)
                             // For small buffers (< 4096 elements), use the actual count as width.
+                            // spirv-cross maps Buffer<T>/RWBuffer<T> to texture2d in MSL.
+                            // spvTexelBufferCoord(tc) = uint2(tc % 4096, tc / 4096)
                             static const uint32_t TEXBUF_WIDTH = 4096;
-                            uint32_t numElements = (uint32_t)(mbuf->_buffer.length / 4);
+                            uint32_t bytesPerElement = isRW ? 16 : 4; // float4 vs uint
+                            MTLPixelFormat texFmt = isRW ? MTLPixelFormatRGBA32Float : MTLPixelFormatR32Uint;
+                            uint32_t numElements = (uint32_t)(mbuf->_buffer.length / bytesPerElement);
                             if (numElements > 0) {
                                 uint32_t width = std::min(numElements, TEXBUF_WIDTH);
-                                uint32_t bytesPerRow = width * 4;
+                                uint32_t bytesPerRow = width * bytesPerElement;
                                 bytesPerRow = (bytesPerRow + 255) & ~255;
                                 uint32_t height = (uint32_t)(mbuf->_buffer.length / bytesPerRow);
                                 if (height < 1) height = 1;
 
                                 MTLTextureDescriptor* td = [MTLTextureDescriptor
-                                    texture2DDescriptorWithPixelFormat:MTLPixelFormatR32Uint
+                                    texture2DDescriptorWithPixelFormat:texFmt
                                                                 width:width
                                                                height:height
                                                             mipmapped:NO];
-                                td.usage = MTLTextureUsageShaderRead;
+                                td.usage = isRW ? (MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite)
+                                                : MTLTextureUsageShaderRead;
                                 td.storageMode = mbuf->_buffer.storageMode;
                                 b.texture = [mbuf->_buffer newTextureWithDescriptor:td
                                                                             offset:0

--- a/src/graphics/metal/MetalBackend_Pipeline.mm
+++ b/src/graphics/metal/MetalBackend_Pipeline.mm
@@ -197,6 +197,7 @@ PipelineStatePointer MetalBackend::createGraphicsPipelineState(const GraphicsPip
 PipelineStatePointer MetalBackend::createComputePipelineState(const ComputePipelineStateInit& init) {
     auto* pso = new MetalPipelineStateBackend();
     pso->initCompute(init);
+    pso->_threadGroupSize = MTLSizeMake(init.threadGroupX, init.threadGroupY, init.threadGroupZ);
 
     // Find the MTLFunction for the compute kernel
     auto* prog = static_cast<MetalShaderBackend*>(init.program.get());

--- a/src/graphics/render/Sky_inc.hlsl
+++ b/src/graphics/render/Sky_inc.hlsl
@@ -22,12 +22,14 @@ struct Atmosphere {
     float4 er_ar_hr_hm;
     float4 betaR; // { 5.8e-6f, 13.5e-6f, 33.1e-6f };   // Rayleygh Scattering
     float4 betaM; // { 4e-6f };                        // Mie Scattering
-
-    float earthRadius() { return er_ar_hr_hm.x; } // = 6360e3;                         // In the paper this is usually Rg or Re (radius ground, eart) 
-    float atmosphereRadius() { return er_ar_hr_hm.y; } // = 6420e3;                    // In the paper this is usually R or Ra (radius atmosphere) 
-    float Hr() { return er_ar_hr_hm.z; } // = 7994;                                    // Thickness of the atmosphere if density was uniform (Hr) 
-    float Hm() { return er_ar_hr_hm.w; } // = 1200;                                    // Same as above but for Mie scattering (Hm) 
 };
+
+// Free functions instead of member functions — spirv-cross generates broken
+// address space qualifiers for member functions on constant-space UBO structs.
+float Atmosphere_earthRadius(Atmosphere a) { return a.er_ar_hr_hm.x; }
+float Atmosphere_atmosphereRadius(Atmosphere a) { return a.er_ar_hr_hm.y; }
+float Atmosphere_Hr(Atmosphere a) { return a.er_ar_hr_hm.z; }
+float Atmosphere_Hm(Atmosphere a) { return a.er_ar_hr_hm.w; }
 
 
 //float3 _SkyColor(const float3 dir) {
@@ -60,10 +62,10 @@ int raySphereIntersect(float3 orig, float3 dir, float sphereRadius, in out float
 }
 
 float3 sky_computeIncidentLight(int4 simDim, Atmosphere atmos, float3 sunDirection, float3 orig, float3 dir, float tmin, float tmax) {
-    float earthRadius = atmos.earthRadius();
-    float atmosphereRadius = atmos.atmosphereRadius();          
-    float Hr = atmos.Hr();   
-    float Hm = atmos.Hm();
+    float earthRadius = Atmosphere_earthRadius(atmos);
+    float atmosphereRadius = Atmosphere_atmosphereRadius(atmos);
+    float Hr = Atmosphere_Hr(atmos);
+    float Hm = Atmosphere_Hm(atmos);
     float3 betaR = atmos.betaR.xyz;
     float3 betaM = atmos.betaM.xyz;
 
@@ -183,10 +185,10 @@ SphericalHarmonics getSkyIrradianceSH() {
 float3 SkyColor(const float3 dir) {
     float3 stage_dir = rotateFrom(skyConstant._stage, dir);
 
-    float3 origin = float3(0, skyConstant._atmosphere.earthRadius() + skyConstant._stage.col_w().y, 0);
+    float3 origin = float3(0, Atmosphere_earthRadius(skyConstant._atmosphere) + skyConstant._stage._backZ_ori.z, 0);
     float t0, t1, tMax = -1.0;
 
-    int testEarth = raySphereIntersect(origin, stage_dir, skyConstant._atmosphere.earthRadius(), t0, t1);
+    int testEarth = raySphereIntersect(origin, stage_dir, Atmosphere_earthRadius(skyConstant._atmosphere), t0, t1);
     if (testEarth && t0 > 0)
         tMax = max(0.f, t0);
 


### PR DESCRIPTION
Sky fixes:
- Replace HLSL member functions (Atmosphere.earthRadius() etc.) with free functions for spirv-cross compatibility with constant address space
- Multi-entry compute shaders: compile all entries, deduplicate struct definitions when concatenating MSL outputs
- Create compute encoder on bindPipeline when binding a compute PSO
- Restart render encoder after compute passes (LoadAction::Load)
- Store thread group size in ComputePipelineStateInit for Metal dispatch
- Fix dispatch to use pipeline's thread group size instead of (1,1,1)

Buffer texture fixes:
- Create texture2d views for RW_RESOURCE_BUFFER (RWBuffer<float4>) using RGBA32Float format with shader read+write usage
- Bind buffer texture views in compute encoder (not just render)
- Use correct bytesPerElement (16 for float4, 4 for uint)

Gamma fix:
- Use R8G8B8A8_UNORM_SRGB as default color format on all platforms so the GPU applies linear→sRGB conversion automatically