### PR TITLE
Add direct sun transmittance for physically correct surface lighting

### DIFF
--- a/src/graphics/drawables/Heightmap_frag.hlsl
+++ b/src/graphics/drawables/Heightmap_frag.hlsl
@@ -104,7 +104,7 @@ float4 main(PixelShaderInput IN) : SV_Target
     float l_dot_h = dot(L, H);
 
     float4 spec_diff_lighting = evalShading(l_dot_h, v_dot_h, max(n_dot_l, 0.0), max(n_dot_h, 0.0), max(n_dot_v, 0.0), roughness2, metallic, F0);
-    float3 sunIntensity = SkyColor(L);
+    float3 sunIntensity = getSunDirLight();
     float3 direct = (spec_diff_lighting.w * base_color + spec_diff_lighting.xyz) * sunIntensity;
 
     float3 color = color_ACESFilmic(ambient + direct);

--- a/src/graphics/drawables/ModelPart_frag.hlsl
+++ b/src/graphics/drawables/ModelPart_frag.hlsl
@@ -144,22 +144,25 @@ float4 main(PixelShaderInput IN) : SV_Target{
     }
 
    // baseColor = drawGrid(IN.Texcoord.xy, baseColor);
-    float3 shading = baseColor;
+    float3 fragLighting = baseColor;
     if (LIGHT_SHADING(_drawMode))
     {
+
+        // Ambient diffuse from sky SH irradiance.
+        // sky_evalIrradianceSH returns E(N) = integral of L(w)*max(N.w,0) dw (cosine kernel already applied).
+        float3 ambient = sky_evalIrradianceSH(normal) * baseColor;
+
+        // Direct lighting from sun
         float3 lightD = getSunDir();
-        float3 lightI = SkyColor(lightD);
+        float3 lightI = getSunDirLight();
 
         float3 n = normal;
-
-        lightI = sky_evalIrradianceSH(n) * M_PI;
-        lightD = n;
-
-        float3 v = normalize(IN.EyePos.xyz); //u_Camera - v_Position);
+        float3 v = normalize(IN.EyePos.xyz);
         float3 l = lightD; //normalize(pointToLight); // Direction from surface point to light
 
-        shading = light_shading(lightI, lightD, v, n, metallic, roughness, baseColor);
+        float3 direct = light_shading(lightI, lightD, v, n, metallic, roughness, baseColor);
 
+        fragLighting = ambient + direct;
     }
 
     float3 emissiveColor = float3 (0.0, 0.0, 0.0);
@@ -167,6 +170,6 @@ float4 main(PixelShaderInput IN) : SV_Target{
         emissiveColor = material_textures.Sample(materialMapSampler(), float3(IN.Texcoord.xy, m.textures.w)).xyz;
     }
 
-    float3 color = color_ACESFilmic(shading + emissiveColor);
+    float3 color = color_ACESFilmic(fragLighting + emissiveColor);
     return float4(color, 1.0);
 }

--- a/src/graphics/render/Sky.cpp
+++ b/src/graphics/render/Sky.cpp
@@ -1,7 +1,7 @@
 // Sky.cpp
 //
 // Sam Gateau - January 2022
-// 
+//
 // MIT License
 //
 // Copyright (c) 2020 Sam Gateau
@@ -39,7 +39,7 @@ Sky::~Sky() {
 }
 
 #define useLocks 1
-#ifdef useLocks 
+#ifdef useLocks
 #define WriteLock() const std::lock_guard<std::mutex> cpulock(_cpuData._access); _cpuData._version++;
 #define ReadLock() const std::lock_guard<std::mutex> cpulock(_cpuData._access);
 
@@ -47,15 +47,61 @@ Sky::~Sky() {
 #define ReadGPULock() const std::lock_guard<std::mutex> gpulock(_gpuData._access);
 #else
 #define WriteLock()  _camData._version++;
-#define ReadLock() 
+#define ReadLock()
 
 #define WriteGPULock() _gpuData._version++;
 #define ReadGPULock()
 #endif
 
+// Compute atmospheric transmittance along the sun direction from the surface.
+// Mirrors the HLSL getSunColor() logic: march from the surface to the top of
+// atmosphere along sunDir, accumulate Rayleigh + Mie optical depth, return
+// exp(-tau) * sunIntensity. Called whenever sun direction or intensity changes.
+static float3 computeSunDirLight(const SkyData& d) {
+    const auto& atmos = d._atmosphere;
+    const float3 sunDir = d._sunDirection;
+    const float earthRadius = atmos.earthRadius;
+    const float atmosphereRadius = atmos.atmosphereRadius;
+    const float Hr = atmos.Hr;
+    const float Hm = atmos.Hm;
+    const float3 betaR = float3(atmos.betaR.x, atmos.betaR.y, atmos.betaR.z);
+    const float betaM = atmos.betaM.x;
+
+    // Observer at surface, offset by stage altitude
+    const float3 origin(0, earthRadius + d._stageRT._columns[3].y, 0);
+
+    // Ray march to top of atmosphere along sun direction
+    const uint32_t numSamples = d._simDim.y;
+
+    // Find t1: exit of atmosphere sphere
+    float p = core::dot(sunDir, origin);
+    float q = core::dot(origin, origin) - atmosphereRadius * atmosphereRadius;
+    float disc = p * p - q;
+    if (disc < 0) return float3(d._sunIntensity); // no intersection
+    float t1 = -p + std::sqrt(disc);
+    if (t1 <= 0) return float3(d._sunIntensity);  // sun below horizon
+
+    float segLen = t1 / numSamples;
+    float tCurrent = 0;
+    float optDepthR = 0, optDepthM = 0;
+
+    for (uint32_t i = 0; i < numSamples; ++i) {
+        float3 samplePos = origin + sunDir * (tCurrent + segLen * 0.5f);
+        float height = core::length(samplePos) - earthRadius;
+        if (height < 0) break;
+        optDepthR += std::exp(-height / Hr) * segLen;
+        optDepthM += std::exp(-height / Hm) * segLen;
+        tCurrent += segLen;
+    }
+
+    float3 tau = betaR * optDepthR + float3(betaM * 1.1f) * optDepthM;
+    return float3(std::exp(-tau.x), std::exp(-tau.y), std::exp(-tau.z)) * d._sunIntensity;
+}
+
 void Sky::setSunDir(const float3& dir) {
     WriteLock();
     _cpuData._data._sunDirection = core::normalize(dir);
+    _cpuData._data._sunDirLight = computeSunDirLight(_cpuData._data);
 }
 float3 Sky::getSunDir() const {
     ReadLock();
@@ -74,6 +120,7 @@ float Sky::getStageAltitude() const {
 void Sky::setSunIntensity(float intensity) {
     WriteLock();
     _cpuData._data._sunIntensity = intensity;
+    _cpuData._data._sunDirLight = computeSunDirLight(_cpuData._data);
 }
 float Sky::getSunIntensity() const {
     ReadLock();

--- a/src/graphics/render/Sky.h
+++ b/src/graphics/render/Sky.h
@@ -54,12 +54,17 @@ namespace graphics {
     struct VISUALIZATION_API SkyData {
         Atmosphere _atmosphere;
         float3 _sunDirection = normalize(float3(0, 1.0, 1.0));
-        float _sunIntensity = 1.0; // This is arbitrary intensity of light that scales the final
+        float _sunIntensity = 20.0; // This is arbitrary intensity of sun light producing the sky color
         core::mat4x3 _stageRT = core::translation(float3(0,0,0));
         core::ivec4 _simDim = { 16, 8 , 1024, 1024};
         core::ivec4 _drawControl = { 0, 0, 0, 0 };
 
         SphericalHarmonics _sh;
+
+        // Direct solar beam color: sunIntensity attenuated by atmospheric transmittance
+        // along the sun direction. Computed on CPU whenever sun params change.
+        float3 _sunDirLight = float3(1.0f, 1.0f, 1.0f);
+        float _spare{ 0 };
     };
 
     class VISUALIZATION_API Sky {

--- a/src/graphics/render/Sky_inc.hlsl
+++ b/src/graphics/render/Sky_inc.hlsl
@@ -61,6 +61,40 @@ int raySphereIntersect(float3 orig, float3 dir, float sphereRadius, in out float
     return (discriminant > 1e-7) ? 2 : 1;
 }
 
+// Transmittance of the atmosphere from 'origin' to the top along 'sunDir'.
+// Returns float3(0) if the ray hits the earth before exiting the atmosphere.
+float3 sky_sunTransmittance(Atmosphere atmos, float3 origin, float3 sunDir, uint numSamples) {
+    float earthRadius      = Atmosphere_earthRadius(atmos);
+    float atmosphereRadius = Atmosphere_atmosphereRadius(atmos);
+    float Hr   = Atmosphere_Hr(atmos);
+    float Hm   = Atmosphere_Hm(atmos);
+    float3 betaR = atmos.betaR.xyz;
+    float  betaM = atmos.betaM.x;
+
+    float t0, t1;
+    raySphereIntersect(origin, sunDir, atmosphereRadius, t0, t1);
+    if (t1 <= 0) return float3(1, 1, 1);
+
+    float segLen = t1 / numSamples;
+    float tCurrent = 0;
+    float optDepthR = 0, optDepthM = 0;
+
+    uint i;
+    for (i = 0; i < numSamples; ++i) {
+        float3 samplePos = origin + sunDir * (tCurrent + segLen * 0.5);
+        float height = length(samplePos) - earthRadius;
+        if (height < 0) break;  // hit the earth
+        optDepthR += exp(-height / Hr) * segLen;
+        optDepthM += exp(-height / Hm) * segLen;
+        tCurrent += segLen;
+    }
+
+    if (i < numSamples) return float3(0, 0, 0);  // ray was blocked by the earth
+
+    float3 tau = betaR * optDepthR + betaM * 1.1 * optDepthM;
+    return float3(exp(-tau.x), exp(-tau.y), exp(-tau.z));
+}
+
 float3 sky_computeIncidentLight(int4 simDim, Atmosphere atmos, float3 sunDirection, float3 orig, float3 dir, float tmin, float tmax) {
     float earthRadius = Atmosphere_earthRadius(atmos);
     float atmosphereRadius = Atmosphere_atmosphereRadius(atmos);
@@ -162,7 +196,9 @@ struct SkyConstant
     Transform _stage;
     int4 _simDims;
     int4 _drawControl;
-    SphericalHarmonics _irradianceSH;
+    SphericalHarmonics _irradianceSH; // Ambient irradiance of the sky evaluated from the sky and sun settings
+    float3 _sunDirLight; // Direct sun light irradiance arriving at the surface of the sky evaluated from the sky and sun settings
+    float _spare;
 };
 
 ConstantBuffer<SkyConstant> skyConstant : register(b11);
@@ -178,6 +214,11 @@ SphericalHarmonics getSkyIrradianceSH() {
     return skyConstant._irradianceSH;
 }
 
+float3 getSunDirLight() {
+    float3 origin = float3(0, Atmosphere_earthRadius(skyConstant._atmosphere) + skyConstant._stage._backZ_ori.z, 0);
+    return sky_sunTransmittance(skyConstant._atmosphere, origin, skyConstant._sunDirection,
+                                (uint) skyConstant._simDims.y) * getSunIntensity();
+}
 
 float3 SkyColor(const float3 dir) {
     float3 stage_dir = rotateFrom(skyConstant._stage, dir);
@@ -191,7 +232,6 @@ float3 SkyColor(const float3 dir) {
 
     return sky_computeIncidentLight(skyConstant._simDims, skyConstant._atmosphere, skyConstant._sunDirection, origin, stage_dir, 0, tMax) * getSunIntensity();
 }
-
 
 
 


### PR DESCRIPTION
Introduce sky_sunTransmittance() in Sky_inc.hlsl: marches from a given point to the top of atmosphere along the sun direction and returns exp(-tau), the fraction of sunlight not scattered away. getSunDirLight() uses it to compute the direct solar beam color inline in the shader.

Mirror the same transmittance march on the CPU (computeSunDirLight) so SkyData._sunDirLight stays in sync with sun direction and intensity changes, keeping the GPU buffer consistent.

Fix ModelPart and Heightmap shaders: separate ambient (SH irradiance * albedo) from direct (getSunDirLight() through the PBR BRDF), replacing the previous SkyColor(sunDir) which was returning scattered glow rather than the direct beam.