### PR TITLE
Replace DedicatedLoop with EventJobHandle; add vsync-driven job graph

### DIFF
--- a/src/core/FileWatcher.cpp
+++ b/src/core/FileWatcher.cpp
@@ -26,6 +26,9 @@
 //
 #include "FileWatcher.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #include <filesystem>
 #include <chrono>
 #include <thread>
@@ -58,6 +61,9 @@ FileWatcher::~FileWatcher() {
 }
 
 void FileWatcher::watchThreadFunction(std::future<void> future, FileWatcher* fw) {
+#ifdef _WIN32
+    SetThreadDescription(GetCurrentThread(), L"pico::FileWatcher");
+#endif
     while (future.wait_for(fw->_delay) == std::future_status::timeout) {
 
         {

--- a/src/core/Job.cpp
+++ b/src/core/Job.cpp
@@ -30,6 +30,22 @@
 
 #include "Log.h"
 
+#ifdef _WIN32
+#include <windows.h>
+static void setThreadName(const std::string& name) {
+    std::wstring wide(name.begin(), name.end());
+    SetThreadDescription(GetCurrentThread(), wide.c_str());
+}
+static std::string threadName(uint32_t i) {
+    if (i < 26)
+        return std::string(1, char('A' + i));
+    i -= 26;
+    return std::string(1, char('A' + i / 26)) + char('A' + i % 26);
+}
+#else
+static void setThreadName(const std::string&) {}
+#endif
+
 namespace core {
 
     // -------------------------------------------------------------------------
@@ -38,7 +54,8 @@ namespace core {
 
     ThreadPool::ThreadPool(uint32_t num_threads) {
         for (uint32_t i = 0; i < num_threads; ++i) {
-            _workers.emplace_back([this] {
+            _workers.emplace_back([this, i] {
+                setThreadName("pico::Job::Thread::" + threadName(i));
                 while (true) {
                     std::function<void()> fn;
                     {
@@ -174,6 +191,13 @@ namespace core {
         _dirty = false;
     }
 
+    void JobGraph::executeOnCurrentThread() {
+        if (_dirty)
+            recomputeTopoOrder();
+        for (auto& job : _topoOrder)
+            job->execute();
+    }
+
     bool JobGraph::execute(ThreadPool& pool) {
         if (_dirty)
             recomputeTopoOrder();
@@ -290,6 +314,141 @@ namespace core {
                     return false;
                 }),
             _oneshot.end());
+    }
+
+    // -------------------------------------------------------------------------
+    // JobGraph::executeDownstreamOf
+    // -------------------------------------------------------------------------
+
+    void JobGraph::executeDownstreamOf(const JobPtr& seedJob, ThreadPool& pool) {
+        if (_dirty)
+            recomputeTopoOrder();
+
+        auto& downstream = _dependents[seedJob.get()];
+        if (downstream.empty())
+            return;
+
+        // Count jobs reachable from seedJob (BFS over _dependents)
+        std::vector<JobPtr> reachable;
+        {
+            std::vector<Job*> frontier;
+            std::unordered_map<Job*, bool> visited;
+            for (auto& j : downstream) {
+                if (!visited[j.get()]) {
+                    visited[j.get()] = true;
+                    frontier.push_back(j.get());
+                    reachable.push_back(j);
+                }
+            }
+            while (!frontier.empty()) {
+                Job* cur = frontier.back(); frontier.pop_back();
+                auto it = _dependents.find(cur);
+                if (it == _dependents.end()) continue;
+                for (auto& j : it->second) {
+                    if (!visited[j.get()]) {
+                        visited[j.get()] = true;
+                        frontier.push_back(j.get());
+                        reachable.push_back(j);
+                    }
+                }
+            }
+        }
+
+        const int total = static_cast<int>(reachable.size());
+
+        // Reset pending counters only for reachable jobs, but count only
+        // inputs that are within the reachable set OR are seedJob itself.
+        std::unordered_map<Job*, bool> reachableSet;
+        reachableSet[seedJob.get()] = true;
+        for (auto& j : reachable) reachableSet[j.get()] = true;
+
+        for (auto& job : reachable) {
+            int pending = 0;
+            for (auto& inp : job->inputJobs())
+                // seedJob is already complete — don't count it as a pending input
+                if (reachableSet.count(inp.get()) && inp.get() != seedJob.get()) ++pending;
+            job->_pending_inputs.store(pending, std::memory_order_relaxed);
+        }
+
+        std::mutex              doneMutex;
+        std::condition_variable doneCV;
+        std::atomic<int>        remaining { total };
+
+        std::function<void(const JobPtr&)> enqueueJob;
+        enqueueJob = [&](const JobPtr& job) {
+            pool.enqueue([&, job]() {
+                job->execute();
+
+                auto it = _dependents.find(job.get());
+                if (it != _dependents.end()) {
+                    for (auto& dep : it->second) {
+                        if (!reachableSet.count(dep.get())) continue;
+                        if (dep->_pending_inputs.fetch_sub(1, std::memory_order_acq_rel) == 1)
+                            enqueueJob(dep);
+                    }
+                }
+
+                if (remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                    std::lock_guard<std::mutex> lock(doneMutex);
+                    doneCV.notify_one();
+                }
+            });
+        };
+
+        // Seed: direct dependents of seedJob whose only pending input is seedJob
+        for (auto& job : downstream)
+            if (job->_pending_inputs.load(std::memory_order_relaxed) == 0)
+                enqueueJob(job);
+
+        std::unique_lock<std::mutex> lock(doneMutex);
+        doneCV.wait(lock, [&] { return remaining.load(std::memory_order_acquire) == 0; });
+    }
+
+    // -------------------------------------------------------------------------
+    // EventJobHandle
+    // -------------------------------------------------------------------------
+
+    EventJobHandle::~EventJobHandle() {
+        _running.store(false);
+        if (_thread.joinable())
+            _thread.join();
+    }
+
+    void EventJobHandle::_loop() {
+        setThreadName("pico::Job::" + _job->name());
+        while (_running.load()) {
+            // Block on the event (vsync etc.) — no mutex held during wait
+            bool fired = _waitFn ? _waitFn(100) : true;
+            if (!_running.load()) break;
+            if (!fired) continue;
+
+            // No-op kernel; marks Trigger output ready (release semantics)
+            _job->execute();
+
+            // Hold frameMutex while dispatching downstream and waiting for completion
+            {
+                std::lock_guard<std::mutex> lock(_frameMutex);
+                _job->graph()->executeDownstreamOf(_job, *_pool);
+            }
+            // Mutex released here — window for resize or other external ops
+        }
+    }
+
+    EventJobHandlePtr JobScheduler::createEventJob(std::string_view name, WaitFn waitFn) {
+        auto handle = std::shared_ptr<EventJobHandle>(new EventJobHandle());
+        handle->_pool    = _pool.get();
+        handle->_waitFn  = std::move(waitFn);
+
+        auto job = Job::create(name);
+        auto trigger_out = job->output<Trigger>("trigger");
+        // No kernel — _loop drives the wait directly; execute() just marks slots ready
+        handle->output = trigger_out;
+        handle->_job   = job;
+
+        handle->_running.store(true);
+        handle->_thread = std::thread([h = handle.get()] { h->_loop(); });
+
+        return handle;
     }
 
 } // namespace core

--- a/src/core/Job.h
+++ b/src/core/Job.h
@@ -192,6 +192,14 @@ namespace core {
         // Returns false if a cycle is detected.
         bool execute(ThreadPool& pool);
 
+        // Execute all jobs sequentially in topo order on the calling thread.
+        void executeOnCurrentThread();
+
+        // Execute all jobs downstream of seedJob using the pool.
+        // seedJob must already have been executed by the caller.
+        // Blocks until all downstream jobs complete.
+        void executeDownstreamOf(const JobPtr& seedJob, ThreadPool& pool);
+
         const std::vector<JobPtr>& jobs() const { return _jobs; }
 
     private:
@@ -353,12 +361,65 @@ namespace core {
         std::atomic<uint32_t> _elapsed_us { 0 };
     };
 
+    // WaitFn: platform-agnostic event wait. Returns true if the event fired,
+    // false on timeout. Used by EventJob to block on e.g. vsync.
+    using WaitFn = std::function<bool(uint32_t timeoutMs)>;
+
+    // Empty signal type — EventJob output that downstream jobs depend on.
+    struct Trigger {};
+
+    // -------------------------------------------------------------------------
+    // EventJobHandle
+    //
+    // Returned by JobScheduler::createEventJob(). Owns the dedicated persistent
+    // thread that blocks on the WaitFn each frame.
+    //
+    // Frame lifecycle on the dedicated thread:
+    //   1. EventJob kernel runs — blocks on WaitFn until event fires
+    //   2. frameMutex acquired
+    //   3. All downstream jobs dispatched to the scheduler's thread pool
+    //   4. Wait for all downstream jobs to complete
+    //   5. frameMutex released  ← window for external code (e.g. resize)
+    //   6. Go to 1
+    //
+    // Wire downstream jobs:
+    //   presentJob->input(vsync->output).kernel([](const Trigger&) { ... });
+    //
+    // Synchronize with resize or other external operations:
+    //   std::lock_guard lock(vsync->frameMutex());
+    //   device->resizeSwapchain(...);
+    // -------------------------------------------------------------------------
+
+    class CORE_API EventJobHandle {
+    public:
+        ~EventJobHandle();
+
+        JobOutput<Trigger>  output;
+        std::mutex&         frameMutex() { return _frameMutex; }
+
+    private:
+        friend class JobScheduler;
+        EventJobHandle() = default;
+
+        WaitFn              _waitFn;
+        JobPtr              _job;
+        std::mutex          _frameMutex;
+        std::atomic<bool>   _running { false };
+        std::thread         _thread;
+        ThreadPool*         _pool { nullptr };
+
+        void _loop();
+    };
+
+    using EventJobHandlePtr = std::shared_ptr<EventJobHandle>;
+
     // -------------------------------------------------------------------------
     // JobScheduler — drives JobGraphs, recurring or one-shot
     //
     //   scheduler.every_frame(graph);          // re-executed each tick()
     //   auto& future = scheduler.once(graph);  // executed once, observable
     //   scheduler.tick();                      // call once per frame, blocks until done
+    //   auto vsync = scheduler.createEventJob("vsync", waitFn);
     // -------------------------------------------------------------------------
 
     class CORE_API JobScheduler {
@@ -370,6 +431,8 @@ namespace core {
         void       every_frame(const JobGraphPtr& graph);
         JobFuture& once(const JobGraphPtr& graph);
         void       tick();
+
+        EventJobHandlePtr createEventJob(std::string_view name, WaitFn waitFn);
 
         uint32_t threadCount() const;
 

--- a/src/graphics/d3d12/D3D12Backend.h
+++ b/src/graphics/d3d12/D3D12Backend.h
@@ -191,6 +191,13 @@ namespace graphics {
         ComPtr<ID3D12Resource> _depthBuffer;
         ComPtr<ID3D12DescriptorHeap> _dsvDescriptorHeap;
         UINT _dsvDescriptorSize { 0 };
+
+        HANDLE _waitableHandle { nullptr };
+        void* waitableHandle() const override { return _waitableHandle; }
+        bool waitVsync(uint32_t timeoutMs) override {
+            if (!_waitableHandle) return true;
+            return WaitForSingleObject(_waitableHandle, timeoutMs) == WAIT_OBJECT_0;
+        }
     };
 
     class D3D12FramebufferBackend : public Framebuffer {

--- a/src/graphics/d3d12/D3D12Backend_Swapchain.cpp
+++ b/src/graphics/d3d12/D3D12Backend_Swapchain.cpp
@@ -93,7 +93,8 @@ ComPtr<IDXGISwapChain4> CreateSwapChain(HWND hWnd,
 //   swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
     swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_UNSPECIFIED;
     // It is recommended to always allow tearing if tearing support is available.
-    swapChainDesc.Flags = CheckTearingSupport() ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+    swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+    if (CheckTearingSupport()) swapChainDesc.Flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
 
     ComPtr<IDXGISwapChain1> swapChain1;
     D3D12Backend_Check(dxgiFactory4->CreateSwapChainForHwnd(
@@ -227,6 +228,8 @@ SwapchainPointer D3D12Backend::createSwapchain(const SwapchainInit& init) {
     sw->_init = init;
     sw->_swapchain = CreateSwapChain((HWND)init.windowHandle, _commandQueue, init.width, init.height, D3D12Backend::Format[(uint32_t)init.colorBufferFormat], D3D12Backend::CHAIN_NUM_FRAMES);
     sw->_currentIndex = sw->_swapchain->GetCurrentBackBufferIndex();
+    sw->_swapchain->SetMaximumFrameLatency(1);
+    sw->_waitableHandle = sw->_swapchain->GetFrameLatencyWaitableObject();
 
     CreateSwapchainRenderTargets(_device, sw);
 

--- a/src/graphics/gpu/Swapchain.h
+++ b/src/graphics/gpu/Swapchain.h
@@ -69,5 +69,10 @@ namespace graphics {
         core::vec4 viewportRect() const { return core::vec4( 0, 0, width(), height());}
 
         FramebufferPointer framebuffer() const { return _framebuffer; }
+
+        virtual void* waitableHandle() const { return nullptr; }
+
+        // Block until the next vblank or timeout. Returns true if vsync fired.
+        virtual bool waitVsync(uint32_t timeoutMs) { return true; }
     };
 }

--- a/src/graphics/render/Viewport.cpp
+++ b/src/graphics/render/Viewport.cpp
@@ -36,6 +36,7 @@
 #include "gpu/Query.h"
 
 
+
 using namespace graphics;
 
 // Allocate a rootLayout just for the scene descriptor set

--- a/test/pico_04/pico_four.cpp
+++ b/test/pico_04/pico_four.cpp
@@ -29,6 +29,7 @@
 #include <chrono>
 
 #include <core/api.h>
+#include <core/Job.h>
 
 #include <graphics/gpu/Device.h>
 #include <graphics/gpu/Resource.h>
@@ -451,19 +452,26 @@ int main(int argc, char *argv[])
     graphics::SwapchainInit swapchainInit{ window->nativeWindow(), window->width(), window->height(), true };
     auto swapchain = gpuDevice->createSwapchain(swapchainInit);
 
+    core::JobScheduler scheduler;
+    auto vsync = scheduler.createEventJob("vsync", [&](uint32_t ms) { return swapchain->waitVsync(ms); });
+
     // On resize deal with it
     windowHandler->_onResizeDelegate = [&](const uix::ResizeEvent& e) {
         // only resize the swapchain when we re done with the resize
         if (e.done) {
+            std::lock_guard<std::mutex> lock(vsync->frameMutex());
             gpuDevice->resizeSwapchain(swapchain, e.width, e.height);
         }
         camControl->onResize(e);
     };
 
     //Now that we have created all the elements,
-    // We configure the windowHandler onPaint delegate of the window to do real rendering!
-    windowHandler->_onPaintDelegate = ([&](const uix::PaintEvent& e) {
-        // Measuring framerate
+    // The present job owns all per-frame work, driven by vsync on its dedicated thread.
+    windowHandler->_onPaintDelegate = nullptr;
+
+    auto presentJob = core::Job::create("present");
+    presentJob->input(vsync->output)
+    .kernel([&](const core::Trigger&) {
         static core::FrameTimer::Sample frameSample;
         auto currentSample = viewport->lastFrameTimerSample();
         if ((currentSample._frameNum - frameSample._frameNum) > 60) {

--- a/test/pico_eye/pico_eye.cpp
+++ b/test/pico_eye/pico_eye.cpp
@@ -40,6 +40,8 @@
 #include <graphics/render/Camera.h>
 #include <graphics/render/Viewport.h>
 
+#include <core/Job.h>
+
 #include <graphics/drawables/SkyDraw.h>
 #include <graphics/drawables/GizmoDraw.h>
 #include <graphics/drawables/PrimitiveDraw.h>
@@ -276,11 +278,20 @@ int main(int argc, char *argv[])
     graphics::SwapchainInit swapchainInit { window->nativeWindow(), window->width(), window->height(), true };
     auto swapchain = gpuDevice->createSwapchain(swapchainInit);
 
-    //Now that we have created all the elements, 
-    // We configure the windowHandler onPaint delegate of the window to do real rendering!
-    windowHandler->_onPaintDelegate = ([&](const uix::PaintEvent& e) {
+    //Now that we have created all the elements,
+    // The present job owns all per-frame work, driven by vsync on its dedicated thread.
+    // onPaint is left empty - input events arrive via their own delegates.
+    windowHandler->_onPaintDelegate = nullptr;
+
+    static core::FrameTimer::Sample frameSample;
+
+    core::JobScheduler scheduler;
+    auto vsync = scheduler.createEventJob("vsync", [&](uint32_t ms) { return swapchain->waitVsync(ms); });
+
+    auto presentJob = core::Job::create("present");
+    presentJob->input(vsync->output)
+    .kernel([&](const core::Trigger&) {
         // Measuring framerate
-        static core::FrameTimer::Sample frameSample;
         auto currentSample = viewport->lastFrameTimerSample();
         if ((currentSample._frameNum - frameSample._frameNum) > 60) {
             frameSample = currentSample;
@@ -371,8 +382,8 @@ int main(int argc, char *argv[])
 
     // On resize deal with it
     windowHandler->_onResizeDelegate = [&](const uix::ResizeEvent& e) {
-        // only resize the swapchain when we re done with the resize
         if (e.done) {
+            std::lock_guard<std::mutex> lock(vsync->frameMutex());
             gpuDevice->resizeSwapchain(swapchain, e.width, e.height);
         }
         camControl->onResize(e);

--- a/test/pico_terrain/pico_terrain.cpp
+++ b/test/pico_terrain/pico_terrain.cpp
@@ -47,6 +47,8 @@
 #include <graphics/render/Scene.h>
 #include <graphics/render/Viewport.h>
 
+#include <core/Job.h>
+
 
 #include <graphics/drawables/SkyDraw.h>
 #include <graphics/drawables/GizmoDraw.h>
@@ -177,12 +179,20 @@ int main(int argc, char *argv[])
     graphics::SwapchainInit swapchainInit { (HWND)window->nativeWindow(), window->width(), window->height(), true };
     auto swapchain = gpuDevice->createSwapchain(swapchainInit);
 
+    //Now that we have created all the elements,
+    // The present job owns all per-frame work, driven by vsync on its dedicated thread.
+    // onPaint is left empty - input events arrive via their own delegates.
+    windowHandler->_onPaintDelegate = nullptr;
 
-    //Now that we have created all the elements, 
-    // We configure the windowHandler onPaint delegate of the window to do real rendering!
-    windowHandler->_onPaintDelegate = ([&](const uix::PaintEvent& e) {
+    static core::FrameTimer::Sample frameSample;
+
+    core::JobScheduler scheduler;
+    auto vsync = scheduler.createEventJob("vsync", [&](uint32_t ms) { return swapchain->waitVsync(ms); });
+
+    auto presentJob = core::Job::create("present");
+    presentJob->input(vsync->output)
+    .kernel([&](const core::Trigger&) {
         // Measuring framerate
-        static core::FrameTimer::Sample frameSample;
         auto currentSample = viewport->lastFrameTimerSample();
         if ((currentSample._frameNum - frameSample._frameNum) > 60) {
             frameSample = currentSample;
@@ -237,8 +247,8 @@ int main(int argc, char *argv[])
 
     // On resize deal with it
     windowHandler->_onResizeDelegate = [&](const uix::ResizeEvent& e) {
-        // only resize the swapchain when we re done with the resize
         if (e.done) {
+            std::lock_guard<std::mutex> lock(vsync->frameMutex());
             gpuDevice->resizeSwapchain(swapchain, e.width, e.height);
         }
 


### PR DESCRIPTION
- Introduce EventJobHandle (created via JobScheduler::createEventJob): dedicated thread blocks on WaitFn without holding any mutex, fires the Trigger output, then holds frameMutex only while downstream jobs run on the pool — opening a gap between frames for resize and other external ops
- Add JobGraph::executeDownstreamOf for pool-based downstream dispatch; fix pending-input count so seedJob is not counted as a pending input
- Add JobScheduler::createEventJob factory
- Name pool worker threads pico::Job::Thread::A/B/C... (AA/AB... beyond Z)
- Name EventJob dedicated threads pico::Job::<jobname>
- Name FileWatcher thread pico::FileWatcher
- Wire pico_04, pico_eye, pico_terrain to vsync EventJob -> present chain